### PR TITLE
Improve PORT checking into nitta-rest-api

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -37,7 +37,7 @@ jobs:
           find src -name '*.hs' -exec grep -l '>>>' {} \; | xargs -t -L 1 -P 4 stack exec doctest
 
       - name: Generate backend API
-        run: stack exec nitta-api-gen
+        run: stack exec nitta-api-gen -- -v
 
       - name: Cache node_modules
         uses: actions/cache@v2.1.3

--- a/app/APIGen.hs
+++ b/app/APIGen.hs
@@ -59,7 +59,7 @@ data APIGen = APIGen
 apiGenArgs =
     APIGen
         { port = 8080 &= help "NITTA UI Backend will start on this port"
-        , output_path = "./web/src/services/gen" &= help "Place the output into specified directory (default: ./web/src/services/gen)"
+        , output_path = apiPath &= help ("Place the output into specified directory (default: " <> apiPath <> ")")
         , verbose = False &= help "Verbose"
         }
         &= program "nitta-api-gen"
@@ -117,11 +117,11 @@ main = do
     infoM "NITTA.APIGen" $ "Expected nitta server port: " <> show port
     writeFile (joinPath [output_path, "PORT"]) $ show port
 
-    infoM "NITTA.APIGen" "Generate rest_api.js library..."
+    infoM "NITTA.APIGen" $ "Generate call library " <> output_path <> "/rest_api.js..."
     prepareJSAPI port output_path
-    infoM "NITTA.APIGen" "Generate rest_api.js library...OK"
+    infoM "NITTA.APIGen" $ "Generate call library " <> output_path <> "/rest_api.js...OK"
 
-    infoM "NITTA.APIGen" "Generate typescript interface..."
+    infoM "NITTA.APIGen" $ "Generate typescript interface " <> output_path <> "/types.ts..."
     let ts =
             formatTSDeclarations $
                 foldl1
@@ -166,8 +166,8 @@ main = do
             , ("[k: T1]", "[k: string]") -- dirty hack for fixing map types for TestbenchReport
             , ("[k: T2]", "[k: string]") -- dirty hack for fixing map types for TestbenchReport
             ]
-    infoM "NITTA.APIGen" "Generate typescript interface...OK"
+    infoM "NITTA.APIGen" $ "Generate typescript interface " <> output_path <> "/types.ts...OK"
 
-    infoM "NITTA.APIGen" "Generate REST API description..."
+    infoM "NITTA.APIGen" $ "Generate REST API description " <> output_path <> "/rest_api.markdown..."
     writeFile (joinPath [output_path, "rest_api.markdown"]) $ restDocs port
-    infoM "NITTA.APIGen" "Generate REST API description...ok"
+    infoM "NITTA.APIGen" $ "Generate REST API description " <> output_path <> "/rest_api.markdown...ok"

--- a/src/NITTA/UIBackend.hs
+++ b/src/NITTA/UIBackend.hs
@@ -20,6 +20,7 @@ module NITTA.UIBackend (
     backendServer,
     prepareJSAPI,
     restDocs,
+    apiPath,
 ) where
 
 import Control.Exception (SomeException, try)
@@ -37,6 +38,8 @@ import qualified Servant.JS as SJS
 import System.FilePath.Posix (joinPath)
 import System.Log.Logger
 import Text.InterpolatedString.Perl6 (qq)
+
+apiPath = joinPath [".", "web", "src", "services", "gen"]
 
 restDocs port =
     markdown $

--- a/web/src/services/HaskellApiService.ts
+++ b/web/src/services/HaskellApiService.ts
@@ -1,7 +1,7 @@
 import { AxiosPromise, AxiosResponse, AxiosError } from "axios";
 import { SID, IAppContext } from "app/AppContext";
 
-import jsAPI from "services/gen/rest_api.js";
+import jsAPI from "services/gen/rest_api";
 import {
   TreeView,
   ShortNodeView,


### PR DESCRIPTION
After fix:
```console
$ stack build :nitta --fast && stack exec nitta -- -t=fx32.32 examples/sum.lua -l -p=8080
nitta: can't find nitta-api info: ./web/src/services/gen/PORT: openFile: does not exist (No such file or directory)
CallStack (from HasCallStack):
  error, called at app/Main.hs:109:48 in main:Main
```