### PR TITLE
Generate app level protocol description for IO process units

### DIFF
--- a/nitta.cabal
+++ b/nitta.cabal
@@ -1,8 +1,10 @@
 cabal-version: 1.18
 
--- This file has been generated from package.yaml by hpack version 0.34.4.
+-- This file has been generated from package.yaml by hpack version 0.33.0.
 --
 -- see: https://github.com/sol/hpack
+--
+-- hash: 38ae9dfec3c729744ade2b144647eb82cfff1075fca88aea4b7a590bfcb55fee
 
 name:           nitta
 version:        0.0.0.1
@@ -116,6 +118,7 @@ library
       HStringTemplate
     , MissingH
     , aeson
+    , aeson-pretty
     , array
     , base
     , boxes

--- a/package.yaml
+++ b/package.yaml
@@ -69,6 +69,7 @@ library:
   dependencies:
     - HStringTemplate
     - aeson
+    - aeson-pretty
     - array
     - directory
     - file-embed

--- a/src/NITTA/Model/ProcessorUnits/IO/I2C.hs
+++ b/src/NITTA/Model/ProcessorUnits/IO/I2C.hs
@@ -24,6 +24,7 @@ module NITTA.Model.ProcessorUnits.IO.I2C (
     IOPorts (..),
 ) where
 
+import Data.Aeson
 import Data.Default
 import Data.String.Interpolate
 import qualified Data.Text as T
@@ -74,8 +75,8 @@ instance IOConnected (I2C v x t) where
     inoutPorts I2CMaster{..} = [masterSDA]
     inoutPorts I2CSlave{..} = [slaveSDA]
 
-instance (VarValTime v x t) => TargetSystemComponent (I2C v x t) where
-    moduleName _ _ = "pu_spi"
+instance (ToJSON v, VarValTime v x t) => TargetSystemComponent (I2C v x t) where
+    moduleName _ _ = "pu_i2c"
     hardware _tag _pu =
         Aggregate
             Nothing
@@ -89,7 +90,8 @@ instance (VarValTime v x t) => TargetSystemComponent (I2C v x t) where
             , FromLibrary "i2c/pu_master_i2c.v"
             , FromLibrary "i2c/pu_slave_i2c.v"
             ]
-    software _ pu = Immediate "transport.txt" $ T.pack $ show pu
+
+    software tag pu = protocolDescription tag pu "I2C Processor Unit"
 
     hardwareInstance
         tag

--- a/src/NITTA/Model/ProcessorUnits/IO/SPI.hs
+++ b/src/NITTA/Model/ProcessorUnits/IO/SPI.hs
@@ -24,11 +24,11 @@ module NITTA.Model.ProcessorUnits.IO.SPI (
     IOPorts (..),
 ) where
 
+import Data.Aeson
 import Data.Default
 import qualified Data.Map.Strict as M
 import Data.Maybe (fromMaybe, mapMaybe)
 import Data.String.Interpolate
-import qualified Data.Text as T
 import NITTA.Intermediate.Functions
 import NITTA.Intermediate.Types
 import NITTA.Model.Problems
@@ -83,7 +83,7 @@ instance IOConnected (SPI v x t) where
 instance (Time t) => Default (SPI v x t) where
     def = anySPI 0
 
-instance (VarValTime v x t) => TargetSystemComponent (SPI v x t) where
+instance (ToJSON v, VarValTime v x t) => TargetSystemComponent (SPI v x t) where
     moduleName _ _ = "pu_spi"
     hardware _tag _pu =
         Aggregate
@@ -98,7 +98,8 @@ instance (VarValTime v x t) => TargetSystemComponent (SPI v x t) where
             , FromLibrary "spi/pu_slave_spi.v"
             , FromLibrary "spi/pu_master_spi.v"
             ]
-    software _ pu = Immediate "transport.txt" $ T.pack $ show pu
+
+    software tag pu = protocolDescription tag pu "SPI Processor Unit"
 
     hardwareInstance
         tag

--- a/src/NITTA/Utils.hs
+++ b/src/NITTA/Utils.hs
@@ -35,6 +35,7 @@ module NITTA.Utils (
     stepsInterval,
     relatedEndpoints,
     isFB,
+    getFBs,
     isInstruction,
     module NITTA.Utils.Base,
 ) where
@@ -109,6 +110,8 @@ isFB s = isJust $ getFB s
 
 getFB Step{pDesc} | FStep fb <- descent pDesc = Just fb
 getFB _ = Nothing
+
+getFBs p = mapMaybe getFB $ sortOn stepStart $ steps p
 
 getEndpoint Step{pDesc} | EndpointRoleStep role <- descent pDesc = Just role
 getEndpoint _ = Nothing

--- a/stack.yaml
+++ b/stack.yaml
@@ -41,7 +41,7 @@ packages:
 # (e.g., acme-missiles-0.3)
 extra-deps:
 - language-lua-0.11.0.1
--   alex-tools-0.5.0.1
+- alex-tools-0.5.0.1
 - aeson-typescript-0.2.0.0
 - servant-js-0.9.4.2@sha256:2419d2cba7ff71926293fa11fc50eaed24a77ba34e7c778eab4cfa1f4bc4a748,3385
 


### PR DESCRIPTION
resolves #37

Example:
```haskell
-- arrange
let f = receive ["a", "b"] :: F String Int
let st0 = i2cUnit 1 :: I2C String Int Int
let Right st1 = tryBind f st0
let s = send "a" :: F String Int
let s2 = send "b" :: F String Int
let Right st2 = tryBind s st1
let Right st3 = tryBind s2 st2
let st4 = endpointDecision st3 $ EndpointSt (Target "a") (0...1)
let st5 = endpointDecision st4 $ EndpointSt (Target "b") (1...2)
let st6 = endpointDecision st5 $ EndpointSt (Source $ fromList ["a", "b"]) (2...3)
-- act
sw = software (pack "example") st6
printf "%s" $ impText sw
{
    "toNitta": [
        "a"
    ],
    "fromNitta": [
        "a",
        "b"
    ],
    "interface": "I2Cinterface",
    "dataType": "Int",
    "description": "I2C Processor Unit"
}
```