### PR TITLE
Refactoring structure of test utility modules

### DIFF
--- a/nitta.cabal
+++ b/nitta.cabal
@@ -225,7 +225,7 @@ test-suite nitta-test
       NITTA.Intermediate.Tests.Functions
       NITTA.Intermediate.Value.Tests
       NITTA.LuaFrontend.Tests
-      NITTA.LuaFrontend.Tests.Utils
+      NITTA.LuaFrontend.Tests.Providers
       NITTA.Model.Problems.Refactor.Accum.Tests
       NITTA.Model.Problems.Refactor.ConstantFolding.Tests
       NITTA.Model.Problems.Refactor.Tests
@@ -237,9 +237,11 @@ test-suite nitta-test
       NITTA.Model.ProcessorUnits.Multiplier.Tests
       NITTA.Model.ProcessorUnits.Shift.Tests
       NITTA.Model.ProcessorUnits.Tests.DSL
-      NITTA.Model.ProcessorUnits.Tests.TestCaseTemplates
+      NITTA.Model.ProcessorUnits.Tests.Providers
       NITTA.Model.ProcessorUnits.Tests.Utils
+      NITTA.Model.Tests.Internals
       NITTA.Model.Tests.Microarchitecture
+      NITTA.Model.Tests.Providers
       NITTA.Tests
       NITTA.Utils.Tests
       Paths_nitta

--- a/test/NITTA/LuaFrontend/Tests.hs
+++ b/test/NITTA/LuaFrontend/Tests.hs
@@ -23,9 +23,7 @@ module NITTA.LuaFrontend.Tests (
 
 import Data.FileEmbed (embedStringFile)
 import Data.String.Interpolate
-import NITTA.LuaFrontend.Tests.Utils
-import NITTA.Model.Networks.Types
-import NITTA.Model.Tests.Microarchitecture
+import NITTA.LuaFrontend.Tests.Providers
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.TH
 

--- a/test/NITTA/LuaFrontend/Tests/Providers.hs
+++ b/test/NITTA/LuaFrontend/Tests/Providers.hs
@@ -10,18 +10,19 @@
 {-# OPTIONS -fno-warn-redundant-constraints #-}
 
 {- |
-Module      : NITTA.LuaFrontend.Tests.Utils
+Module      : NITTA.LuaFrontend.Tests.Providers
 Description :
 Copyright   : (c) Aleksandr Penskoi, 2020
 License     : BSD3
 Maintainer  : aleksandr.penskoi@gmail.com
 Stability   : experimental
 -}
-module NITTA.LuaFrontend.Tests.Utils (
+module NITTA.LuaFrontend.Tests.Providers (
     luaTestCase,
     typedLuaTestCase,
     typedIOLuaTestCase,
     traceLuaSimulationTestCase,
+    module NITTA.Model.Tests.Microarchitecture,
 ) where
 
 import Data.CallStack
@@ -33,6 +34,7 @@ import NITTA.Intermediate.Types
 import NITTA.LuaFrontend
 import NITTA.Model.Networks.Bus
 import NITTA.Model.Networks.Types
+import NITTA.Model.Tests.Internals
 import NITTA.Model.Tests.Microarchitecture
 import NITTA.Project
 import NITTA.Synthesis
@@ -81,6 +83,8 @@ typedIOLuaTestCase arch proxy name received src = testCase name $ do
     case status of
         Left err -> assertFailure err
         Right _ -> return ()
+
+-- Internals
 
 runLua ::
     forall x.

--- a/test/NITTA/Model/Problems/Refactor/ConstantFolding/Tests.hs
+++ b/test/NITTA/Model/Problems/Refactor/ConstantFolding/Tests.hs
@@ -23,7 +23,7 @@ import qualified Data.Set as S
 import Data.String.Interpolate
 import NITTA.Intermediate.Functions
 import NITTA.Intermediate.Types
-import NITTA.LuaFrontend.Tests.Utils
+import NITTA.LuaFrontend.Tests.Providers
 import NITTA.Model.Problems.Refactor
 import Test.Tasty (testGroup)
 import Test.Tasty.HUnit

--- a/test/NITTA/Model/ProcessorUnits/Accum/Tests.hs
+++ b/test/NITTA/Model/ProcessorUnits/Accum/Tests.hs
@@ -19,15 +19,9 @@ module NITTA.Model.ProcessorUnits.Accum.Tests (
 import Data.Default
 import qualified Data.Set as S
 import Data.String.Interpolate
-import NITTA.Intermediate.Functions
-import NITTA.Intermediate.Tests.Functions ()
-import NITTA.Intermediate.Types
-import NITTA.LuaFrontend.Tests.Utils
-import NITTA.Model.Networks.Types
-import NITTA.Model.ProcessorUnits
-import NITTA.Model.ProcessorUnits.Tests.DSL
-import NITTA.Model.ProcessorUnits.Tests.TestCaseTemplates
-import NITTA.Model.Tests.Microarchitecture
+import NITTA.LuaFrontend.Tests.Providers
+import NITTA.Model.ProcessorUnits.Tests.Providers
+import NITTA.Model.Tests.Providers
 import Test.QuickCheck
 import Test.Tasty (testGroup)
 

--- a/test/NITTA/Model/ProcessorUnits/Broken/Tests.hs
+++ b/test/NITTA/Model/ProcessorUnits/Broken/Tests.hs
@@ -23,13 +23,9 @@ module NITTA.Model.ProcessorUnits.Broken.Tests (
 
 import Data.Default
 import Data.String.Interpolate
-import NITTA.Intermediate.Functions
-import NITTA.Intermediate.Tests.Functions ()
-import NITTA.Intermediate.Types
-import NITTA.LuaFrontend.Tests.Utils
-import NITTA.Model.ProcessorUnits
-import NITTA.Model.ProcessorUnits.Tests.TestCaseTemplates
-import NITTA.Model.Tests.Microarchitecture
+import NITTA.LuaFrontend.Tests.Providers
+import NITTA.Model.ProcessorUnits.Tests.Providers
+import NITTA.Model.Tests.Providers
 import Test.QuickCheck
 import Test.Tasty (testGroup)
 import Test.Tasty.ExpectedFailure

--- a/test/NITTA/Model/ProcessorUnits/Divider/Tests.hs
+++ b/test/NITTA/Model/ProcessorUnits/Divider/Tests.hs
@@ -18,14 +18,9 @@ module NITTA.Model.ProcessorUnits.Divider.Tests (
 
 import Data.Default
 import Data.String.Interpolate
-import NITTA.Intermediate.Functions
-import NITTA.Intermediate.Types
-import NITTA.LuaFrontend.Tests.Utils
-import NITTA.Model.Networks.Types
-import NITTA.Model.ProcessorUnits
-import NITTA.Model.ProcessorUnits.Tests.DSL
-import NITTA.Model.ProcessorUnits.Tests.TestCaseTemplates
-import NITTA.Model.Tests.Microarchitecture
+import NITTA.LuaFrontend.Tests.Providers
+import NITTA.Model.ProcessorUnits.Tests.Providers
+import NITTA.Model.Tests.Providers
 import Test.Tasty (testGroup)
 import Test.Tasty.ExpectedFailure
 

--- a/test/NITTA/Model/ProcessorUnits/Fram/Tests.hs
+++ b/test/NITTA/Model/ProcessorUnits/Fram/Tests.hs
@@ -18,12 +18,7 @@ module NITTA.Model.ProcessorUnits.Fram.Tests (
 ) where
 
 import Data.Default
-import NITTA.Intermediate.Functions
-import NITTA.Intermediate.Tests.Functions ()
-import NITTA.Intermediate.Types
-import NITTA.Model.ProcessorUnits
-import NITTA.Model.ProcessorUnits.Tests.DSL
-import NITTA.Model.ProcessorUnits.Tests.TestCaseTemplates
+import NITTA.Model.ProcessorUnits.Tests.Providers
 import Test.QuickCheck
 import Test.Tasty (testGroup)
 

--- a/test/NITTA/Model/ProcessorUnits/IO/SPI/Tests.hs
+++ b/test/NITTA/Model/ProcessorUnits/IO/SPI/Tests.hs
@@ -22,15 +22,15 @@ import Data.Default
 import Data.String.Interpolate
 import qualified Data.Text as T
 import NITTA.Intermediate.DataFlow
-import qualified NITTA.Intermediate.Functions as F
-import NITTA.Intermediate.Tests.Functions ()
-import NITTA.LuaFrontend.Tests.Utils
-import NITTA.Model.Networks.Types
-import NITTA.Model.Tests.Microarchitecture
+import NITTA.LuaFrontend.Tests.Providers
+import NITTA.Model.Tests.Internals
+import NITTA.Model.Tests.Providers
 import NITTA.Synthesis
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit
 import Test.Tasty.TH
+
+-- FIXME: avoid NITTA.Model.Tests.Internals usage
 
 test_multiple_receives =
     [ testCase "receive two variables" $
@@ -42,10 +42,10 @@ test_multiple_receives =
                     , tReceivedValues = [("a", [10 .. 15]), ("b", [20 .. 25])]
                     , tDFG =
                         fsToDataFlowGraph
-                            [ F.receive ["a"]
-                            , F.receive ["b"]
-                            , F.add "a" "b" ["c"]
-                            , F.send "c"
+                            [ receive ["a"]
+                            , receive ["b"]
+                            , add "a" "b" ["c"]
+                            , send "c"
                             ]
                     }
     , testCase "receive variable two times" $
@@ -57,9 +57,9 @@ test_multiple_receives =
                     , tReceivedValues = [("a", [10 .. 15]), ("b", [20 .. 25])]
                     , tDFG =
                         fsToDataFlowGraph
-                            [ F.receive ["a", "b"]
-                            , F.add "a" "b" ["c"]
-                            , F.send "c"
+                            [ receive ["a", "b"]
+                            , add "a" "b" ["c"]
+                            , send "c"
                             ]
                     }
     ]

--- a/test/NITTA/Model/ProcessorUnits/Multiplier/Tests.hs
+++ b/test/NITTA/Model/ProcessorUnits/Multiplier/Tests.hs
@@ -17,15 +17,9 @@ module NITTA.Model.ProcessorUnits.Multiplier.Tests (
 ) where
 
 import Data.String.Interpolate
-import NITTA.Intermediate.Functions
-import NITTA.Intermediate.Tests.Functions ()
-import NITTA.Intermediate.Types
-import NITTA.LuaFrontend.Tests.Utils
-import NITTA.Model.Networks.Types
-import NITTA.Model.ProcessorUnits
-import NITTA.Model.ProcessorUnits.Tests.DSL
-import NITTA.Model.ProcessorUnits.Tests.TestCaseTemplates
-import NITTA.Model.Tests.Microarchitecture
+import NITTA.LuaFrontend.Tests.Providers
+import NITTA.Model.ProcessorUnits.Tests.Providers
+import NITTA.Model.Tests.Providers
 import Test.QuickCheck
 import Test.Tasty (testGroup)
 import Test.Tasty.ExpectedFailure

--- a/test/NITTA/Model/ProcessorUnits/Shift/Tests.hs
+++ b/test/NITTA/Model/ProcessorUnits/Shift/Tests.hs
@@ -14,10 +14,8 @@ module NITTA.Model.ProcessorUnits.Shift.Tests (
 ) where
 
 import Data.String.Interpolate
-import NITTA.Intermediate.Functions
-import NITTA.LuaFrontend.Tests.Utils
-import NITTA.Model.ProcessorUnits.Tests.TestCaseTemplates
-import NITTA.Model.Tests.Microarchitecture
+import NITTA.LuaFrontend.Tests.Providers
+import NITTA.Model.Tests.Providers
 import Test.Tasty (testGroup)
 
 tests =

--- a/test/NITTA/Model/ProcessorUnits/Tests/Providers.hs
+++ b/test/NITTA/Model/ProcessorUnits/Tests/Providers.hs
@@ -8,49 +8,49 @@
 {-# LANGUAGE UndecidableInstances #-}
 
 {-# OPTIONS -fno-warn-redundant-constraints #-}
+{-# OPTIONS -fno-warn-dodgy-exports #-}
 
 {- |
-Module      : NITTA.Model.ProcessorUnits.Tests.Utils
+Module      : NITTA.Model.ProcessorUnits.Tests.Providers
 Description : Utils for processor unit testing
 Copyright   : (c) Aleksandr Penskoi, 2020
 License     : BSD3
 Maintainer  : aleksandr.penskoi@gmail.com
 Stability   : experimental
 -}
-module NITTA.Model.ProcessorUnits.Tests.TestCaseTemplates (
+module NITTA.Model.ProcessorUnits.Tests.Providers (
     puCoSimTestCase,
-    nittaCoSimTestCase,
     finitePUSynthesisProp,
     puCoSimProp,
+    module NITTA.Model.ProcessorUnits,
+    module NITTA.Intermediate.Functions,
+    module NITTA.Intermediate.Types,
+    module NITTA.Intermediate.Tests.Functions,
+    module NITTA.Model.ProcessorUnits.Tests.DSL,
     module NITTA.Model.ProcessorUnits.Tests.Utils,
 ) where
 
 import Control.Monad
-import Data.Atomics.Counter (incrCounter)
 import Data.CallStack
 import Data.Data
 import Data.Default
-import qualified Data.String.Utils as S
 import qualified Data.Text as T
-import NITTA.Intermediate.DataFlow
-import NITTA.Intermediate.Functions ()
+import NITTA.Intermediate.Functions
+import NITTA.Intermediate.Tests.Functions ()
 import NITTA.Intermediate.Types
-import NITTA.Model.Networks.Bus
 import NITTA.Model.Networks.Types
 import NITTA.Model.Problems hiding (Bind, BreakLoop)
+import NITTA.Model.ProcessorUnits
 import NITTA.Model.ProcessorUnits.Tests.DSL
 import NITTA.Model.ProcessorUnits.Tests.Utils
-import NITTA.Model.TargetSystem ()
-import NITTA.Model.Tests.Microarchitecture
+import NITTA.Model.Tests.Internals
 import NITTA.Project
 import qualified NITTA.Project as P
-import NITTA.Synthesis
 import NITTA.Utils
 import System.Directory
 import System.FilePath.Posix (joinPath)
 import Test.QuickCheck.Monadic
 import Test.Tasty (TestTree)
-import Test.Tasty.HUnit (assertBool, assertFailure, testCase)
 import Test.Tasty.QuickCheck (testProperty)
 
 -- *Test cases
@@ -73,29 +73,6 @@ puCoSimTestCase name u cntxCycle alg =
     puUnitTestCase name u $ do
         assignsNaive alg cntxCycle
         assertNaiveCoSimulation
-
--- |Execute co-simulation test for the specific microarchitecture and algorithm
-nittaCoSimTestCase ::
-    ( HasCallStack
-    , Val x
-    , Integral x
-    ) =>
-    String ->
-    BusNetwork String String x Int ->
-    [F String x] ->
-    TestTree
-nittaCoSimTestCase n tMicroArch alg =
-    testCase n $ do
-        report <-
-            runTargetSynthesisWithUniqName
-                def
-                    { tName = S.replace " " "_" n
-                    , tMicroArch
-                    , tDFG = fsToDataFlowGraph alg
-                    }
-        case report of
-            Right report' -> assertBool "report with bad status" $ tbStatus report'
-            Left err -> assertFailure $ "can't get report: " ++ err
 
 -- *Properties
 

--- a/test/NITTA/Model/Tests/Internals.hs
+++ b/test/NITTA/Model/Tests/Internals.hs
@@ -1,0 +1,29 @@
+{-# LANGUAGE NamedFieldPuns #-}
+
+{- |
+Module      : NITTA.Model.Tests.Internals
+Description : Internals utils for model tests
+Copyright   : (c) Aleksandr Penskoi, 2021
+License     : BSD3
+Maintainer  : aleksandr.penskoi@gmail.com
+Stability   : experimental
+-}
+module NITTA.Model.Tests.Internals (
+    externalTestCntr,
+    incrCounter,
+    runTargetSynthesisWithUniqName,
+) where
+
+import Data.Atomics.Counter (incrCounter, newCounter)
+import NITTA.Synthesis
+import System.IO.Unsafe (unsafePerformIO)
+
+-- TODO: replace by function like: uniqTestPath :: FilePath -> IO FilePath
+
+-- |Dirty hack to avoid collision with parallel QuickCheck.
+externalTestCntr = unsafePerformIO $ newCounter 0
+{-# NOINLINE externalTestCntr #-}
+
+runTargetSynthesisWithUniqName t@TargetSynthesis{tName} = do
+    i <- incrCounter 1 externalTestCntr
+    runTargetSynthesis t{tName = tName <> "_" <> show i}

--- a/test/NITTA/Model/Tests/Microarchitecture.hs
+++ b/test/NITTA/Model/Tests/Microarchitecture.hs
@@ -3,7 +3,6 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PartialTypeSignatures #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -23,9 +22,6 @@ module NITTA.Model.Tests.Microarchitecture (
     marchSPI,
     marchSPIDropData,
     maBroken,
-    algTestCase,
-    externalTestCntr,
-    runTargetSynthesisWithUniqName,
     microarch,
     IOUnit (..),
     pInt,
@@ -38,22 +34,15 @@ module NITTA.Model.Tests.Microarchitecture (
     pFX42_64,
     pAttrIntX32,
     pAttrFX22_32,
+    module NITTA.Model.Networks.Types,
 ) where
 
-import Control.Monad (void)
-import Data.Atomics.Counter (incrCounter, newCounter)
-import Data.Default
 import Data.Proxy
-import NITTA.Intermediate.DataFlow
 import NITTA.Intermediate.Types
 import NITTA.Model.Microarchitecture
 import NITTA.Model.Networks.Bus
 import NITTA.Model.Networks.Types
 import NITTA.Model.ProcessorUnits
-import NITTA.Model.TargetSystem ()
-import NITTA.Synthesis
-import System.IO.Unsafe (unsafePerformIO)
-import Test.Tasty.HUnit
 
 pInt = Proxy :: Proxy Int
 
@@ -150,29 +139,11 @@ marchSPIDropData isSlave proxy = (marchSPI isSlave proxy){ioSync = ASync}
 
 -----------------------------------------------------------
 
--- |Dirty hack to avoid collision with parallel QuickCheck.
-externalTestCntr = unsafePerformIO $ newCounter 0
-{-# NOINLINE externalTestCntr #-}
-
-runTargetSynthesisWithUniqName t@TargetSynthesis{tName} = do
-    i <- incrCounter 1 externalTestCntr
-    runTargetSynthesis t{tName = tName ++ "_" ++ show i}
-
-algTestCase n tMicroArch alg =
-    testCase n $
-        void $
-            runTargetSynthesisWithUniqName
-                (def :: TargetSynthesis _ _ _ Int)
-                    { tName = n
-                    , tMicroArch
-                    , tDFG = fsToDataFlowGraph alg
-                    }
-
 data IOUnit
     = MasterSPI
     | SlaveSPI
 
-microarch ioSync ioUnit = defineNetwork "net1" ioSync $ do
+microarch ioSync' ioUnit = defineNetwork "net1" ioSync' $ do
     add "fram1" FramIO
     add "fram2" FramIO
     add "shift" ShiftIO

--- a/test/NITTA/Model/Tests/Providers.hs
+++ b/test/NITTA/Model/Tests/Providers.hs
@@ -1,0 +1,74 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE PartialTypeSignatures #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+{-# OPTIONS -fno-warn-redundant-constraints #-}
+{-# OPTIONS -fno-warn-partial-type-signatures #-}
+
+{- |
+Module      : NITTA.Model.Tests.Providers
+Description : Utils for processor unit testing
+Copyright   : (c) Aleksandr Penskoi, 2020
+License     : BSD3
+Maintainer  : aleksandr.penskoi@gmail.com
+Stability   : experimental
+-}
+module NITTA.Model.Tests.Providers (
+    nittaCoSimTestCase,
+    algTestCase,
+    module NITTA.Intermediate.Functions,
+    module NITTA.Model.Tests.Microarchitecture,
+) where
+
+import Control.Monad (void)
+import Data.CallStack
+import Data.Default
+import qualified Data.String.Utils as S
+import NITTA.Intermediate.DataFlow
+import NITTA.Intermediate.Functions
+import NITTA.Intermediate.Types
+import NITTA.Model.Networks.Bus
+import NITTA.Model.Tests.Internals
+import NITTA.Model.Tests.Microarchitecture
+import NITTA.Project
+import NITTA.Synthesis
+import Test.Tasty (TestTree)
+import Test.Tasty.HUnit (assertBool, assertFailure, testCase)
+
+-- |Execute co-simulation test for the specific microarchitecture and algorithm
+nittaCoSimTestCase ::
+    ( HasCallStack
+    , Val x
+    , Integral x
+    ) =>
+    String ->
+    BusNetwork String String x Int ->
+    [F String x] ->
+    TestTree
+nittaCoSimTestCase n tMicroArch alg =
+    testCase n $ do
+        report <-
+            runTargetSynthesisWithUniqName
+                def
+                    { tName = S.replace " " "_" n
+                    , tMicroArch
+                    , tDFG = fsToDataFlowGraph alg
+                    }
+        case report of
+            Right report' -> assertBool "report with bad status" $ tbStatus report'
+            Left err -> assertFailure $ "can't get report: " ++ err
+
+algTestCase n tMicroArch alg =
+    testCase n $
+        void $
+            runTargetSynthesisWithUniqName
+                (def :: TargetSynthesis _ _ _ Int)
+                    { tName = n
+                    , tMicroArch
+                    , tDFG = fsToDataFlowGraph alg
+                    }

--- a/test/NITTA/Tests.hs
+++ b/test/NITTA/Tests.hs
@@ -32,12 +32,14 @@ import NITTA.Intermediate.Types
 import NITTA.Model.Networks.Types
 import NITTA.Model.Problems
 import NITTA.Model.ProcessorUnits
-import NITTA.Model.TargetSystem ()
-import NITTA.Model.Tests.Microarchitecture
+import NITTA.Model.Tests.Internals
+import NITTA.Model.Tests.Providers
 import NITTA.Synthesis
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit
 import Test.Tasty.TH
+
+-- FIXME: avoid NITTA.Model.Tests.Internals usage
 
 {-# ANN module "HLint: ignore Reduce duplication" #-}
 


### PR DESCRIPTION
*.Tests.Providers - element of TestTree in accordance to Tasty (including DSL)
Reexports to reduce amount of imports in tests (by Providers)

Only this module should be imported for writing tests.