### PR TITLE
175 display help if no args provided

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -48,6 +48,8 @@ import NITTA.UIBackend
 import NITTA.Utils
 import Paths_nitta
 import System.Console.CmdArgs hiding (def)
+import qualified System.Console.CmdArgs.Explicit as CMD
+import qualified System.Environment as Env
 import System.Exit
 import System.FilePath.Posix
 import System.IO (stdout)
@@ -130,9 +132,17 @@ nittaArgs =
     where
         defTemplates = S.join ":" defProjectTemplates
 
+getNittaArgs :: IO Nitta
+getNittaArgs = do
+    let mode = cmdArgsMode nittaArgs
+    result <- CMD.process mode <$> Env.getArgs
+    case result of
+        Left _ -> Env.withArgs ["--help"] (cmdArgs nittaArgs)
+        Right a -> cmdArgsApply a
+
 main = do
     Nitta{port, filename, uarch, type_, io_sync, fsim, lsim, n, verbose, extra_verbose, output_path, templates, format} <-
-        cmdArgs nittaArgs
+        getNittaArgs
     setupLogger verbose extra_verbose
 
     toml <- case uarch of

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -48,7 +48,7 @@ import NITTA.UIBackend
 import NITTA.Utils
 import Paths_nitta
 import System.Console.CmdArgs hiding (def)
-import qualified System.Environment as Env
+import System.Console.CmdArgs.Explicit (helpText, HelpFormat(HelpFormatDefault))
 import System.Exit
 import System.FilePath.Posix
 import System.IO (stdout)
@@ -134,7 +134,9 @@ nittaArgs =
 getNittaArgs :: IO Nitta
 getNittaArgs = do
     let handleError :: ExitCode -> IO Nitta
-        handleError _ = Env.withArgs ["--help"] (cmdArgs nittaArgs)
+        handleError exitCode = do
+            print $ helpText [] HelpFormatDefault $ cmdArgsMode nittaArgs
+            exitWith exitCode
     catch (cmdArgs nittaArgs) handleError
 
 main = do

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -48,7 +48,6 @@ import NITTA.UIBackend
 import NITTA.Utils
 import Paths_nitta
 import System.Console.CmdArgs hiding (def)
-import qualified System.Console.CmdArgs.Explicit as CMD
 import qualified System.Environment as Env
 import System.Exit
 import System.FilePath.Posix
@@ -134,11 +133,9 @@ nittaArgs =
 
 getNittaArgs :: IO Nitta
 getNittaArgs = do
-    let mode = cmdArgsMode nittaArgs
-    result <- CMD.process mode <$> Env.getArgs
-    case result of
-        Left _ -> Env.withArgs ["--help"] (cmdArgs nittaArgs)
-        Right a -> cmdArgsApply a
+    let handleError :: ExitCode -> IO Nitta
+        handleError _ = Env.withArgs ["--help"] (cmdArgs nittaArgs)
+    catch (cmdArgs nittaArgs) handleError
 
 main = do
     Nitta{port, filename, uarch, type_, io_sync, fsim, lsim, n, verbose, extra_verbose, output_path, templates, format} <-


### PR DESCRIPTION
Running `stack run nitta` will result in the following output:
```
Requires at least 1 arguments, got 0
nitta v0.0.0.1 - tool for hard real-time CGRA processors

nitta [OPTIONS] FILE

Target system configuration:
         --uarch=PATH                  Microarchitecture configuration file
  -t     --type=fxM.B                  Overrides data type specified in
                                       config file
         --io-sync=sync|async|onboard  Overrides IO synchronization mode
                                       specified in config file
         --templates=PATH[:PATH]       Target platform templates (default:
                                       'templates/Icarus:templates/DE0-Nano')
Common flags:
  -p     --port=INT                    Run nitta server for UI on specific
                                       port (by default - not run)
  -o     --output-path=PATH            Target system path
Simulation:
  -n=INT                               Number of simulation cycles
  -f     --fsim                        Functional simulation with trace
  -l     --lsim                        Logical (HDL) simulation with trace
         --format=md|json|csv          Simulation output format (default:
                                       'md')
Other:
  -v     --verbose                     Verbose
  -e     --extra-verbose               Extra verbose
  -?     --help                        Display help message
  -V     --version                     Print version information
         --numeric-version             Print just the version number
```