### PR TITLE
Introduce ProcessWaves

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -31,6 +31,7 @@
 - ignore: {name: "Avoid lambda using `infix`", within: "NITTA.Project.Template"}
 - ignore: {name: "Reduce duplication", within: "NITTA.Model.Tests.Microarchitecture"}
 - ignore: {name: "Use list comprehension", within: "Spec"}
+- ignore: {name: "Fuse mapM_/map", within: "NITTA.Intermediate.Simulation.Tests"}
 
 - ignore: {name: "Reduce duplication", within: "NITTA.Model.ProcessorUnits.Multiplier.Tests"}
 - ignore: {name: "Reduce duplication", within: "NITTA.Model.ProcessorUnits.Divider.Tests"}

--- a/nitta.cabal
+++ b/nitta.cabal
@@ -37,6 +37,7 @@ extra-doc-files:
 
 library
   exposed-modules:
+      NITTA.Intermediate.Analysis
       NITTA.Intermediate.DataFlow
       NITTA.Intermediate.Functions
       NITTA.Intermediate.Functions.Accum

--- a/src/NITTA/Intermediate/Analysis.hs
+++ b/src/NITTA/Intermediate/Analysis.hs
@@ -1,0 +1,158 @@
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+{- |
+Module      : NITTA.Intermediate.Analysis
+Description : Analysis of the process execution flow
+Copyright   : (c) Aleksandr Penskoi, 2022
+License     : BSD3
+Maintainer  : aleksandr.penskoi@gmail.com
+Stability   : experimental
+
+Much of the work in this module focuses on building waves of process execution.
+In this case, we call a wave a set of functions that are ready for execution (all input vars are ready to use)
+and that can be performed independently of each other.
+Example:
+
+Lua code:
+
+@
+function sum(a)
+    local d = a + 1
+    sum(d)
+end
+sum(0)
+@
+
+After building DataFlowGraph, we get the following set of functions:
+
+@
+- const(1) = !1#0
+- loop(0, d^0#0) = a^0#0
+- a^0#0 + !1#0 = d^0#0
+@
+
+Const and Loop function can be executed at the first wave because all input variables are ready to use.
+After executing first wave a^0#0 and !1#0 will be ready, so we will be able to execute add function.
+So the resulting process waves are the following:
+
+@
+[
+    ProcessWave {
+        pwFs = [const(1) = !1#0,loop(0, d^0#0) = a^0#0],
+        pwOut = fromList ["!1#0","a^0#0"]
+    },
+    ProcessWave {
+        pwFs = [a^0#0 + !1#0 = d^0#0],
+        pwOut = fromList ["d^0#0"]
+    }
+]
+@
+-}
+module NITTA.Intermediate.Analysis (
+    ProcessWave (..),
+    buildProcessWaves,
+    reorderAlgorithm,
+    estimateVarWaves,
+) where
+
+import qualified Data.List as L
+import qualified Data.Map as M
+import qualified Data.Set as S
+import GHC.Generics
+import NITTA.Intermediate.Functions
+import NITTA.Intermediate.Types
+import NITTA.Utils.Base
+
+data ProcessWave v x = ProcessWave
+    { -- |Functions that can be executed at this wave
+      pwFs :: [F v x]
+    , -- |Set of output variables related to the functions from this step
+      pwOut :: S.Set v
+    }
+    deriving (Show, Generic)
+
+data Builder v x = Builder
+    { -- |Functions that can be calculated due to lack of ready input values
+      pwRemains :: S.Set (F v x)
+    , -- |Variables that defined at the beginning of the process
+      pwIn :: S.Set v
+    , -- |Variables that is ready to be used us inputs
+      pwReadyIn :: S.Set v
+    , -- |Resulting process flow
+      pwGraph :: [ProcessWave v x]
+    }
+    deriving (Show, Generic)
+
+{- |
+Sort functions in order of execution.
+Note that some function could be executed in parallel, in this case we save order from the source list.
+-}
+reorderAlgorithm :: (Var v, Val x) => [F v x] -> [F v x]
+reorderAlgorithm alg = concatMap pwFs $ buildProcessWaves [] alg
+
+{- |
+Functions can be divided into waves of execution.
+For each output variable, we define the wave number on which the variable will be defined.
+-}
+estimateVarWaves :: (Var v, Val x, Num a) => [v] -> [F v x] -> M.Map v a
+estimateVarWaves alreadyVars fs = M.fromList $ go 0 $ buildProcessWaves alreadyVars fs
+    where
+        go n (ProcessWave{pwFs} : pss) = go (n + 1) pss <> [(out, n) | out <- S.toList $ unionsMap outputs pwFs]
+        go _ [] = []
+
+-- |Divide function into execution waves.
+buildProcessWaves :: (Var v, Val x) => [v] -> [F v x] -> [ProcessWave v x]
+buildProcessWaves vars fs =
+    let pwIn = S.fromList vars
+        (loops, other) = L.partition isLoop fs
+        beginning =
+            -- Place all loops at the beginning of the algorithm to avoid circular dependencies in functions.
+            [ ProcessWave
+                { pwFs = loops
+                , pwOut = unionsMap outputs loops
+                }
+            | not (null loops)
+            ]
+        builder =
+            Builder
+                { pwRemains = S.fromList other
+                , pwGraph = beginning
+                , pwIn
+                , pwReadyIn = pwIn `S.union` unionsMap pwOut beginning
+                }
+     in pwGraph $ execBuilder builder 0
+
+execBuilder :: Ord v => Builder v x -> Int -> Builder v x
+execBuilder builder@Builder{pwRemains} prev
+    | S.null pwRemains = builder
+    | S.size pwRemains == prev = error "Process waves construction stuck in a loop"
+    | otherwise = execBuilder (foldl applyRemaining builder pwRemains) $ S.size pwRemains
+
+applyRemaining :: Ord v => Builder v x -> F v x -> Builder v x
+applyRemaining builder@Builder{pwRemains, pwGraph, pwIn, pwReadyIn} func =
+    let fIn = inputs func
+        fOut = outputs func
+        pendingIn = S.difference fIn pwReadyIn
+     in if not $ null pendingIn
+            then builder
+            else
+                builder
+                    { pwReadyIn = S.union fOut pwReadyIn
+                    , pwGraph = insertF func (S.difference fIn pwIn) fOut pwGraph
+                    , pwRemains = S.delete func pwRemains
+                    }
+
+insertF :: Ord v => F v x -> S.Set v -> S.Set v -> [ProcessWave v x] -> [ProcessWave v x]
+insertF f fIn fOut []
+    | null fIn = [ProcessWave{pwFs = [f], pwOut = fOut}]
+    | otherwise = error "Cannot calculate process wave for the function"
+insertF f fIn fOut (ps@ProcessWave{pwFs, pwOut} : pss)
+    | null fIn = ps{pwFs = f : pwFs, pwOut = S.union fOut pwOut} : pss
+    | otherwise = ps : insertF f (S.difference fIn pwOut) fOut pss

--- a/src/NITTA/Intermediate/Functions.hs
+++ b/src/NITTA/Intermediate/Functions.hs
@@ -42,6 +42,7 @@ module NITTA.Intermediate.Functions (
     -- *Memory
     Constant (..),
     constant,
+    isConst,
     Loop (..),
     loop,
     isLoop,
@@ -349,6 +350,9 @@ instance (Var v, Show x) => Show (Constant v x) where
     show (Constant (X x) os) = "const(" <> show x <> ") = " <> show os
 constant :: (Var v, Val x) => x -> [v] -> F v x
 constant x vs = packF $ Constant (X x) $ O $ fromList vs
+isConst f
+    | Just Constant{} <- castF f = True
+    | otherwise = False
 
 instance (Show x, Eq x, Typeable x) => Function (Constant v x) v where
     outputs (Constant _ o) = variables o

--- a/src/NITTA/Intermediate/Simulation.hs
+++ b/src/NITTA/Intermediate/Simulation.hs
@@ -17,17 +17,15 @@ Stability   : experimental
 module NITTA.Intermediate.Simulation (
     simulateDataFlowGraph,
     simulateAlg,
-    reorderAlgorithm,
 ) where
 
 import qualified Data.HashMap.Strict as HM
-import Data.List (intersect, (\\))
 import qualified Data.Map.Strict as M
 import Data.Set (elems)
 import Data.String.Interpolate
+import NITTA.Intermediate.Analysis (reorderAlgorithm)
 import NITTA.Intermediate.Functions
 import NITTA.Intermediate.Types
-import NITTA.Utils
 
 -- |Functional algorithm simulation
 simulateDataFlowGraph ::
@@ -104,18 +102,3 @@ simulateAlg' fromPrevCycle cycleCntx0 transmission alg =
                 )
                 cntx00
                 fs
-
-reorderAlgorithm alg = orderAlgorithm' [] alg
-    where
-        orderAlgorithm' _ [] = []
-        orderAlgorithm' vs fs
-            | loops@(_ : _) <- filter isLoop fs
-              , let loopOutputs = elems $ unionsMap outputs loops =
-                case filter (not . null . intersect loopOutputs . elems . inputs) loops of
-                    [] -> loops ++ orderAlgorithm' (elems (unionsMap variables loops) ++ vs) (fs \\ loops)
-                    ready -> ready ++ orderAlgorithm' (elems (unionsMap variables ready) ++ vs) (fs \\ ready)
-        orderAlgorithm' vs fs
-            | let ready = filter (null . (\\ vs) . elems . inputs) fs
-              , not $ null ready =
-                ready ++ orderAlgorithm' (elems (unionsMap variables ready) ++ vs) (fs \\ ready)
-        orderAlgorithm' _ remain = error $ "Can't sort algorithm: " ++ show remain

--- a/src/NITTA/Model/Problems/Refactor/ConstantFolding.hs
+++ b/src/NITTA/Model/Problems/Refactor/ConstantFolding.hs
@@ -94,10 +94,6 @@ instance (Var v, Val x) => ConstantFoldingProblem [F v x] v x where
         | cRefOld == cRefNew = cRefNew
         | otherwise = deleteExtraF $ (fs L.\\ cRefOld) <> cRefNew
 
-isConst f
-    | Just Constant{} <- castF f = True
-    | otherwise = False
-
 selectClusters fs =
     let consts = filter isConst fs
         isIntersection a b = not . S.null $ S.intersection a b

--- a/test/NITTA/Model/ProcessorUnits/Tests/DSL.hs
+++ b/test/NITTA/Model/ProcessorUnits/Tests/DSL.hs
@@ -108,6 +108,7 @@ module NITTA.Model.ProcessorUnits.Tests.DSL (
     tracePU,
     traceProcess,
     traceRefactor,
+    traceProcessWaves,
 ) where
 
 import Control.Monad.Identity
@@ -122,6 +123,7 @@ import Data.String.ToString
 import qualified Data.String.Utils as S
 import qualified Data.Text as T
 import Data.Typeable
+import NITTA.Intermediate.Analysis (buildProcessWaves)
 import NITTA.Intermediate.DataFlow
 import NITTA.Intermediate.Simulation
 import NITTA.Intermediate.Types
@@ -554,6 +556,11 @@ traceDataflow = do
     UnitTestState{unit = TargetSystem{mUnit}} <- get
     lift $ putListLn "Dataflow:" $ dataflowOptions mUnit
 
+traceProcessWaves :: TSStatement x ()
+traceProcessWaves = do
+    UnitTestState{unit = TargetSystem{mDataFlowGraph}} <- get
+    lift $ putStrLn $ showArray $ buildProcessWaves [] $ functions mDataFlowGraph
+
 traceBind :: TSStatement x ()
 traceBind = do
     UnitTestState{unit = TargetSystem{mUnit}} <- get
@@ -570,3 +577,5 @@ traceRefactor = do
 putListLn name opts = do
     putStrLn name
     mapM_ (\b -> putStrLn $ "- " <> show b) opts
+
+showArray l = S.join "\n\t" (map show l)


### PR DESCRIPTION
part of #155

Note that behavior of some function has changed. 

1. See changes in test for reorder algorithm (Now we save original order of the functions that could be execute in parallel)
2. See estimateWaves function
It used to be
```
let f = estimateWaves :: [F String Int] -> [String] -> M.Map String Int
     l1 = loop 0 "b2" ["a1"]
     l2 = loop 1 "c" ["b1", "b2"]
     a = add "a1" "b1" ["c"]
     M.fromList [] @=? f [l1, l2, a] [] -- because there's no ready vars
     
let f = estimateWaves :: [F String Int] -> [String] -> M.Map String Int
     l1 = loop 0 "b2" ["a1"]
     l2 = loop 1 "c" ["b1", "b2"]
     a = add "a1" "b1" ["c"]
     M.fromList [("a1",0),("b1",1),("b2",1),("c",0)] @=? f [l1, l2, a] ["a1", "b1", "b2"]
```
And current behavior are visible in tests
