### PR TITLE
Refactoring & getTreeInfo speedup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
           key: ${{ runner.os }}-haskell-stack-${{ hashFiles('**/stack.yaml', '**/package.yaml') }}
 
       - name: Install haskell-stack
-        uses: haskell/actions/setup@v2.3.3
+        uses: haskell/actions/setup@v2.4.3
         with:
           enable-stack: true
           stack-no-global: true

--- a/examples/fibonacci.lua
+++ b/examples/fibonacci.lua
@@ -3,3 +3,10 @@ function fib(a, b)
     fib(a, b)
 end
 fib(0, 1)
+
+-- Value:    1 1 2 3 5 8
+-- Cycle 1:  a b
+-- Cycle 2:    a b
+-- Cycle 3:      a b
+-- Cycle 4:        a b
+-- Cycle 5:          a b

--- a/src/NITTA/Synthesis/Analysis.hs
+++ b/src/NITTA/Synthesis/Analysis.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE BangPatterns #-}
-
 {- |
 Module      : NITTA.Synthesis.Analysis
 Description : Analysis synthesis proccess.

--- a/src/NITTA/Synthesis/Analysis.hs
+++ b/src/NITTA/Synthesis/Analysis.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE BangPatterns #-}
+
 {- |
 Module      : NITTA.Synthesis.Analysis
 Description : Analysis synthesis proccess.
@@ -20,10 +22,10 @@ import NITTA.Synthesis.Types
 
 -- | Metrics of synthesis tree process
 data TreeInfo = TreeInfo
-    { nodes :: Int
-    , success :: Int
-    , failed :: Int
-    , notProcessed :: Int
+    { nodes :: !Int
+    , success :: !Int
+    , failed :: !Int
+    , notProcessed :: !Int
     , durationSuccess :: HM.HashMap Int Int
     , stepsSuccess :: HM.HashMap Int Int
     }
@@ -39,8 +41,8 @@ instance Semigroup TreeInfo where
                 , success = sum $ map success synthesisInfoList
                 , failed = sum $ map failed synthesisInfoList
                 , notProcessed = sum $ map notProcessed synthesisInfoList
-                , durationSuccess = if not $ null durationSuccessList then foldl1 (HM.unionWith (+)) durationSuccessList else HM.empty
-                , stepsSuccess = if not $ null stepsSuccessList then foldl1 (HM.unionWith (+)) stepsSuccessList else HM.empty
+                , durationSuccess = if not $ null durationSuccessList then foldr1 (HM.unionWith (+)) durationSuccessList else HM.empty
+                , stepsSuccess = if not $ null stepsSuccessList then foldr1 (HM.unionWith (+)) stepsSuccessList else HM.empty
                 }
 
 instance Monoid TreeInfo where

--- a/src/NITTA/Synthesis/Analysis.hs
+++ b/src/NITTA/Synthesis/Analysis.hs
@@ -17,7 +17,6 @@ import Control.Concurrent.STM
 import Data.HashMap.Strict qualified as HM
 import GHC.Generics
 import NITTA.Model.TargetSystem (processDuration)
-import NITTA.Synthesis.Explore (isComplete, isLeaf)
 import NITTA.Synthesis.Types
 
 -- | Metrics of synthesis tree process

--- a/src/NITTA/Synthesis/Analysis.hs
+++ b/src/NITTA/Synthesis/Analysis.hs
@@ -57,8 +57,9 @@ instance Monoid TreeInfo where
 getTreeInfo tree@Tree{sID = Sid sid, sSubForestVar} = do
     subForestM <- atomically $ tryReadTMVar sSubForestVar
     subForestInfo <- maybe (return mempty) (fmap mconcat . mapM getTreeInfo) subForestM
-    let isSuccess = isComplete tree && isLeaf tree
-    let isFail = (not . isComplete) tree && isLeaf tree
+    let (isSuccess, isFail)
+            | isLeaf tree = if isComplete tree then (True, False) else (False, True)
+            | otherwise = (False, False)
     let duration = fromEnum $ processDuration $ sTarget $ sState tree
     let successDepends value field =
             if not isSuccess

--- a/src/NITTA/Synthesis/Explore.hs
+++ b/src/NITTA/Synthesis/Explore.hs
@@ -17,8 +17,6 @@ module NITTA.Synthesis.Explore (
     getTreePathIO,
     subForestIO,
     positiveSubForestIO,
-    isComplete,
-    isLeaf,
 ) where
 
 import Control.Concurrent.STM

--- a/src/NITTA/Synthesis/Explore.hs
+++ b/src/NITTA/Synthesis/Explore.hs
@@ -44,12 +44,15 @@ synthesisTreeRootIO = atomically . rootSynthesisTreeSTM
 
 rootSynthesisTreeSTM model = do
     sSubForestVar <- newEmptyTMVar
+    let sState = nodeCtx Nothing model
     return
         Tree
             { sID = def
-            , sState = nodeCtx Nothing model
+            , sState
             , sDecision = Root
             , sSubForestVar
+            , isLeaf = isLeaf' sState
+            , isComplete = isComplete' sState
             }
 
 -- | Get specific by @nId@ node from a synthesis tree.
@@ -105,22 +108,20 @@ subForest (objective function value less than zero).
 -}
 positiveSubForestIO tree = filter ((> 0) . defScore . sDecision) <$> subForestIO tree
 
-isLeaf
-    Tree
-        { sState =
-            SynthesisState
-                { sAllocationOptions = []
-                , sBindOptions = []
-                , sDataflowOptions = []
-                , sBreakLoopOptions = []
-                , sResolveDeadlockOptions = []
-                , sOptimizeAccumOptions = []
-                , sConstantFoldingOptions = []
-                }
+isLeaf'
+    SynthesisState
+        { sAllocationOptions = []
+        , sBindOptions = []
+        , sDataflowOptions = []
+        , sBreakLoopOptions = []
+        , sResolveDeadlockOptions = []
+        , sOptimizeAccumOptions = []
+        , sConstantFoldingOptions = []
         } = True
-isLeaf _ = False
+isLeaf' _ = False
 
-isComplete = isSynthesisComplete . sTarget . sState
+isComplete' = isSynthesisComplete . sTarget
+
 -- * Internal
 
 exploreSubForestVar parent@Tree{sID, sState} =
@@ -142,6 +143,8 @@ exploreSubForestVar parent@Tree{sID, sState} =
                     , sState = ctx'
                     , sDecision = desc
                     , sSubForestVar
+                    , isLeaf = isLeaf' ctx'
+                    , isComplete = isComplete' ctx'
                     }
 
 decisionAndContext parent@Tree{sState = ctx} o =

--- a/src/NITTA/Synthesis/Steps/Bind.hs
+++ b/src/NITTA/Synthesis/Steps/Bind.hs
@@ -105,9 +105,9 @@ instance
             , (pAlternative == 1) <?> 500
             , pAllowDataFlow * 10
             , pPercentOfBindedInputs * 50
-            , fromMaybe (-1) pWave * 50
-            , pNumberOfBindedFunctions * 10
-            , pRestless * 4
+            , -fromMaybe (-1) pWave * 50
+            , -pNumberOfBindedFunctions * 10
+            , -pRestless * 4
             , pOutputNumber * 2
             ]
 

--- a/src/NITTA/Synthesis/Steps/Bind.hs
+++ b/src/NITTA/Synthesis/Steps/Bind.hs
@@ -99,23 +99,17 @@ instance
 
     estimate _ctx _o _d BindMetrics{pPossibleDeadlock = True} = 500
     estimate _ctx _o _d BindMetrics{pCritical, pAlternative, pAllowDataFlow, pRestless, pNumberOfBindedFunctions, pWave, pPercentOfBindedInputs, pOutputNumber} =
-        3000
-            + pCritical
-            <?> 1000
-            + (pAlternative == 1)
-            <?> 500
-            + pAllowDataFlow
-            * 10
-            + pPercentOfBindedInputs
-            * 50
-            - fromMaybe (-1) pWave
-            * 50
-            - pNumberOfBindedFunctions
-            * 10
-            - pRestless
-            * 4
-            + pOutputNumber
-            * 2
+        sum
+            [ 3000
+            , pCritical <?> 1000
+            , (pAlternative == 1) <?> 500
+            , pAllowDataFlow * 10
+            , pPercentOfBindedInputs * 50
+            , fromMaybe (-1) pWave * 50
+            , pNumberOfBindedFunctions * 10
+            , pRestless * 4
+            , pOutputNumber * 2
+            ]
 
 waitingTimeOfVariables net =
     [ (variable, inf $ tcAvailable constrain)

--- a/src/NITTA/Synthesis/Steps/Dataflow.hs
+++ b/src/NITTA/Synthesis/Steps/Dataflow.hs
@@ -101,14 +101,13 @@ instance
             , pRestrictedTime
             , pFirstWaveOfTargetUse
             } =
-            2000
-                + (numberOfDataflowOptions >= threshold)
-                <?> 1000
-                + pRestrictedTime
-                <?> 200
-                - sum pNotTransferableInputs
-                * 5
-                - pWaitTime
-                - pFirstWaveOfTargetUse
+            sum
+                [ 2000
+                , (numberOfDataflowOptions >= threshold) <?> 1000
+                , pRestrictedTime <?> 200
+                , sum pNotTransferableInputs * (-5)
+                , -pWaitTime
+                , -pFirstWaveOfTargetUse
+                ]
 
 threshold = 20

--- a/src/NITTA/Synthesis/Types.hs
+++ b/src/NITTA/Synthesis/Types.hs
@@ -118,6 +118,8 @@ data Tree m tag v x t = Tree
     , sDecision :: SynthesisDecision (SynthesisState m tag v x t) m
     , sSubForestVar :: TMVar [Tree m tag v x t]
     -- ^ lazy mutable field with different synthesis options and sub nodes
+    , isLeaf :: Bool
+    , isComplete :: Bool
     }
 
 targetUnit = mUnit . sTarget . sState


### PR DESCRIPTION
`stack build && stack exec nitta -- -p=8080 -t=fx32.32 examples/sin_ident/sin_ident.lua`

Performance of `time http GET localhost:8080/treeInfo`:

1. Before optimisation:
    
    ```shell
    Executed in   19.20 secs      fish           external
    ```

2. After predicate rewriting (https://github.com/ryukzak/nitta/commit/f262ad3e5dbfd3f665eb543145f57763b734e2a8):

    ```shell
    Executed in    2.02 secs      fish           external
    ```

3. After Force strictness (https://github.com/ryukzak/nitta/commit/c80ae1ad83d951907f335b126d4c2fb9d57b54ae):

    ```shell
    Executed in    1.93 secs      fish           external
    ```

4. After extraction isLeaf and isComplete to tree data (https://github.com/ryukzak/nitta/commit/8020ccbb194958c218ad35c7db130419eaa44fe9):

    ```shell
    Executed in    1.86 secs      fish           external
    ```

close #153