### PR TITLE
Group binding

### DIFF
--- a/src/NITTA/Intermediate/Types.hs
+++ b/src/NITTA/Intermediate/Types.hs
@@ -30,6 +30,7 @@ module NITTA.Intermediate.Types (
     FView (..),
     packF,
     castF,
+    functionType,
     Function (..),
     Lock (..),
     Locks (..),
@@ -193,6 +194,8 @@ data F v x where
         F v x
 
 packF f = F{fun = f, funHistory = []}
+
+functionType F{fun} = typeOf fun
 
 instance Eq (F v x) where
     F{fun = a} == F{fun = b}

--- a/src/NITTA/Intermediate/Types.hs
+++ b/src/NITTA/Intermediate/Types.hs
@@ -195,6 +195,7 @@ data F v x where
 
 packF f = F{fun = f, funHistory = []}
 
+functionType :: F v x -> TypeRep
 functionType F{fun} = typeOf fun
 
 instance Eq (F v x) where

--- a/src/NITTA/Model/Networks/Bus.hs
+++ b/src/NITTA/Model/Networks/Bus.hs
@@ -346,7 +346,13 @@ bindsHash BusNetwork{bnPus, bnBinded} binds =
                         fs' =
                             S.fromList $
                                 if mergeFunctionWithSameType
-                                    then map (show . (\lst -> (head lst, length lst))) (L.group $ map functionType fs)
+                                    then -- TODO: merge only functions without
+                                    -- inputs, because they are equal from
+                                    -- scheduling point of view
+
+                                    -- TODO: other way to reduce numner of
+                                    -- combinations
+                                        map (show . (\lst -> (head lst, length lst))) (L.group $ map functionType fs)
                                     else map show fs
                      in
                         (unitType u, binded, fs')
@@ -373,7 +379,8 @@ instance
 
             notObliviousBinds :: [[(tag, F v x)]]
             notObliviousBinds = filter ((> 1) . length) binds
-            -- TODO: split this on several independent tasks. It should significantly reduce complexity
+            -- TODO: split them on independent bindGroups. It should
+            -- significantly reduce complexity.
             multiBinds :: [Bind tag v x]
             multiBinds
                 | null notObliviousBinds = []

--- a/src/NITTA/Model/Networks/Bus.hs
+++ b/src/NITTA/Model/Networks/Bus.hs
@@ -350,7 +350,7 @@ bindsHash BusNetwork{bnPus, bnBinded} binds =
                                     -- inputs, because they are equal from
                                     -- scheduling point of view
 
-                                    -- TODO: other way to reduce numner of
+                                    -- TODO: other way to reduce number of
                                     -- combinations
                                         map (show . (\lst -> (head lst, length lst))) (L.group $ map functionType fs)
                                     else map show fs

--- a/src/NITTA/Model/Networks/Bus.hs
+++ b/src/NITTA/Model/Networks/Bus.hs
@@ -318,7 +318,7 @@ fixGroupBinding bn@BusNetwork{bnPus} (b@(tag, f) : binds)
     | Right _ <- tryBind f (bnPus M.! tag) = b : fixGroupBinding (bindDecision bn $ Bind f tag) binds
     | otherwise = fixGroupBinding bn binds
 
-mergeFunctionWithSameType = False
+mergeFunctionWithSameType = True
 
 {- | GroupBindHash required to find equal from task point of view bindings.
  E.g. (we have 2 units and 3 functions with the same type):

--- a/src/NITTA/Model/Networks/Bus.hs
+++ b/src/NITTA/Model/Networks/Bus.hs
@@ -303,6 +303,15 @@ cartesianProduct :: [[a]] -> [[a]]
 cartesianProduct [] = [[]]
 cartesianProduct (xs : xss) = [x : ys | x <- xs, ys <- cartesianProduct xss]
 
+{- | Not all bindings can be applied to unit a the same time. E.g.:
+
+ - @b = reg(a)@
+ - @c = reg(b)@
+
+ Can't be binded to same unit because it require self sending of data.
+
+ In this case, we just throw away conflicted bindings.
+-}
 fixGroupBinding :: (UnitTag tag, VarValTime v x t) => BusNetwork tag v x t -> [(tag, F v x)] -> [(tag, F v x)]
 fixGroupBinding _bn [] = []
 fixGroupBinding bn@BusNetwork{bnPus} (b@(tag, f) : binds)

--- a/src/NITTA/Model/Networks/Bus.hs
+++ b/src/NITTA/Model/Networks/Bus.hs
@@ -391,7 +391,7 @@ instance
                                 nubNotObliviousBinds bn $
                                     cartesianProduct notObliviousBinds
 
-            simpleBinds = concatMap (map (\(uTag, f) -> SingleBind uTag f)) binds
+            simpleBinds = concatMap (map $ uncurry SingleBind) binds
          in singleAssingmentBinds <> multiBinds <> simpleBinds
         where
             optionsFor f =

--- a/src/NITTA/Model/Networks/Types.hs
+++ b/src/NITTA/Model/Networks/Types.hs
@@ -64,6 +64,7 @@ data PU v x t where
         } ->
         PU v x t
 
+unitType :: PU v x t -> TypeRep
 unitType PU{unit} = typeOf unit
 
 instance Ord v => EndpointProblem (PU v x t) v t where

--- a/src/NITTA/Model/Networks/Types.hs
+++ b/src/NITTA/Model/Networks/Types.hs
@@ -12,6 +12,7 @@ Stability   : experimental
 -}
 module NITTA.Model.Networks.Types (
     PU (..),
+    unitType,
     PUClasses,
     IOSynchronization (..),
     PUPrototype (..),
@@ -50,6 +51,7 @@ type PUClasses pu v x t =
     , Controllable pu
     , IOTestBench pu v x
     , Locks pu v
+    , Typeable pu
     )
 
 -- | Existential container for a processor unit .
@@ -61,6 +63,8 @@ data PU v x t where
         , uEnv :: UnitEnv pu
         } ->
         PU v x t
+
+unitType PU{unit} = typeOf unit
 
 instance Ord v => EndpointProblem (PU v x t) v t where
     endpointOptions PU{diff, unit} =

--- a/src/NITTA/Model/Problems/Bind.hs
+++ b/src/NITTA/Model/Problems/Bind.hs
@@ -26,7 +26,7 @@ import NITTA.Utils.Base (unionsMap)
 
 data Bind tag v x
     = Bind (F v x) tag -- FIXME: swap arguments sequence
-    | Binds {isSingleAssignment :: Bool, bindGroup :: M.Map tag [F v x]}
+    | Binds {isObliviousBinds :: Bool, bindGroup :: M.Map tag [F v x]}
     deriving (Generic, Eq)
 
 bindGroup2binds :: Bind tag v x -> [(tag, F v x)]
@@ -50,10 +50,10 @@ binds2bindGroup binds =
 
 instance UnitTag tag => Show (Bind tag v x) where
     show (Bind f tag) = "Bind " <> showFAndTag (f, tag)
-    show (Binds{isSingleAssignment, bindGroup}) =
+    show (Binds{isObliviousBinds, bindGroup}) =
         concat
             [ "Binds "
-            , if isSingleAssignment then "SingleAssignment " else ""
+            , if isObliviousBinds then "obliviousBinds " else ""
             , S.join "; " (map showFsAndTag $ M.assocs bindGroup)
             ]
 

--- a/src/NITTA/Model/Problems/Bind.hs
+++ b/src/NITTA/Model/Problems/Bind.hs
@@ -12,7 +12,6 @@ Stability   : experimental
 module NITTA.Model.Problems.Bind (
     Bind (..),
     BindProblem (..),
-    bindGroup2binds,
     binds2bindGroup,
 ) where
 
@@ -28,10 +27,6 @@ data Bind tag v x
     = Bind (F v x) tag -- FIXME: swap arguments sequence
     | Binds {isObliviousBinds :: Bool, bindGroup :: M.Map tag [F v x]}
     deriving (Generic, Eq)
-
-bindGroup2binds :: Bind tag v x -> [(tag, F v x)]
-bindGroup2binds (Bind f tag) = [(tag, f)]
-bindGroup2binds Binds{bindGroup} = [(tag, f) | (tag, fs) <- M.assocs bindGroup, f <- fs]
 
 binds2bindGroup :: UnitTag tag => [(tag, F v x)] -> M.Map tag [F v x]
 binds2bindGroup binds =

--- a/src/NITTA/Model/Problems/Bind.hs
+++ b/src/NITTA/Model/Problems/Bind.hs
@@ -24,8 +24,8 @@ import NITTA.Model.ProcessorUnits.Types (UnitTag)
 import NITTA.Utils.Base (unionsMap)
 
 data Bind tag v x
-    = Bind tag (F v x)
-    | Binds {isObliviousBinds :: Bool, bindGroup :: M.Map tag [F v x]}
+    = SingleBind tag (F v x)
+    | GroupBind {isObliviousBinds :: Bool, bindGroup :: M.Map tag [F v x]}
     deriving (Generic, Eq)
 
 binds2bindGroup :: UnitTag tag => [(tag, F v x)] -> M.Map tag [F v x]
@@ -44,8 +44,8 @@ binds2bindGroup binds =
         binds
 
 instance UnitTag tag => Show (Bind tag v x) where
-    show (Bind uTag f) = "Bind " <> showFAndTag (f, uTag)
-    show (Binds{isObliviousBinds, bindGroup}) =
+    show (SingleBind uTag f) = "Bind " <> showFAndTag (f, uTag)
+    show (GroupBind{isObliviousBinds, bindGroup}) =
         concat
             [ "Binds "
             , if isObliviousBinds then "obliviousBinds " else ""
@@ -63,9 +63,9 @@ class BindProblem u tag v x | u -> tag v x where
     bindDecision :: u -> Bind tag v x -> u
 
 instance Var v => Variables (Bind tab v x) v where
-    variables (Bind _tag f) = variables f
-    variables Binds{bindGroup} = unionsMap variables $ concat $ M.elems bindGroup
+    variables (SingleBind _tag f) = variables f
+    variables GroupBind{bindGroup} = unionsMap variables $ concat $ M.elems bindGroup
 
 instance WithFunctions (Bind tag v x) (F v x) where
-    functions (Bind _tag f) = [f]
-    functions Binds{bindGroup} = concat $ M.elems bindGroup
+    functions (SingleBind _tag f) = [f]
+    functions GroupBind{bindGroup} = concat $ M.elems bindGroup

--- a/src/NITTA/Model/Problems/Bind.hs
+++ b/src/NITTA/Model/Problems/Bind.hs
@@ -12,18 +12,55 @@ Stability   : experimental
 module NITTA.Model.Problems.Bind (
     Bind (..),
     BindProblem (..),
+    bindGroup2binds,
+    binds2bindGroup,
 ) where
 
+import Data.Map.Strict qualified as M
 import Data.String.ToString
+import Data.String.Utils qualified as S
 import GHC.Generics
 import NITTA.Intermediate.Types
+import NITTA.Model.ProcessorUnits.Types (UnitTag)
+import NITTA.Utils.Base (unionsMap)
 
 data Bind tag v x
-    = Bind (F v x) tag
+    = Bind (F v x) tag -- FIXME: swap arguments sequence
+    | Binds {isSingleAssignment :: Bool, bindGroup :: M.Map tag [F v x]}
     deriving (Generic, Eq)
 
-instance ToString tag => Show (Bind tag v x) where
-    show (Bind f tag) = "Bind " <> show f <> " " <> toString tag
+bindGroup2binds :: Bind tag v x -> [(tag, F v x)]
+bindGroup2binds (Bind f tag) = [(tag, f)]
+bindGroup2binds Binds{bindGroup} = [(tag, f) | (tag, fs) <- M.assocs bindGroup, f <- fs]
+
+binds2bindGroup :: UnitTag tag => [(tag, F v x)] -> M.Map tag [F v x]
+binds2bindGroup binds =
+    foldl
+        ( \st (tag, f) ->
+            M.alter
+                ( \case
+                    (Just fs) -> Just $ f : fs
+                    Nothing -> Just [f]
+                )
+                tag
+                st
+        )
+        M.empty
+        binds
+
+instance UnitTag tag => Show (Bind tag v x) where
+    show (Bind f tag) = "Bind " <> showFAndTag (f, tag)
+    show (Binds{isSingleAssignment, bindGroup}) =
+        concat
+            [ "Binds "
+            , if isSingleAssignment then "SingleAssignment " else ""
+            , S.join "; " (map showFsAndTag $ M.assocs bindGroup)
+            ]
+
+showFAndTag :: UnitTag tag => (F v x, tag) -> String
+showFAndTag (f, tag) = toString tag <> " <- " <> show f
+
+showFsAndTag (tag, fs) = toString tag <> " <- " <> S.join ", " (map show fs)
 
 class BindProblem u tag v x | u -> tag v x where
     bindOptions :: u -> [Bind tag v x]
@@ -31,3 +68,8 @@ class BindProblem u tag v x | u -> tag v x where
 
 instance Var v => Variables (Bind tab v x) v where
     variables (Bind f _tag) = variables f
+    variables Binds{bindGroup} = unionsMap variables $ concat $ M.elems bindGroup
+
+instance WithFunctions (Bind tag v x) (F v x) where
+    functions (Bind f _tag) = [f]
+    functions Binds{bindGroup} = concat $ M.elems bindGroup

--- a/src/NITTA/Model/Problems/Bind.hs
+++ b/src/NITTA/Model/Problems/Bind.hs
@@ -24,7 +24,7 @@ import NITTA.Model.ProcessorUnits.Types (UnitTag)
 import NITTA.Utils.Base (unionsMap)
 
 data Bind tag v x
-    = Bind (F v x) tag -- FIXME: swap arguments sequence
+    = Bind tag (F v x)
     | Binds {isObliviousBinds :: Bool, bindGroup :: M.Map tag [F v x]}
     deriving (Generic, Eq)
 
@@ -44,7 +44,7 @@ binds2bindGroup binds =
         binds
 
 instance UnitTag tag => Show (Bind tag v x) where
-    show (Bind f tag) = "Bind " <> showFAndTag (f, tag)
+    show (Bind uTag f) = "Bind " <> showFAndTag (f, uTag)
     show (Binds{isObliviousBinds, bindGroup}) =
         concat
             [ "Binds "
@@ -63,9 +63,9 @@ class BindProblem u tag v x | u -> tag v x where
     bindDecision :: u -> Bind tag v x -> u
 
 instance Var v => Variables (Bind tab v x) v where
-    variables (Bind f _tag) = variables f
+    variables (Bind _tag f) = variables f
     variables Binds{bindGroup} = unionsMap variables $ concat $ M.elems bindGroup
 
 instance WithFunctions (Bind tag v x) (F v x) where
-    functions (Bind f _tag) = [f]
+    functions (Bind _tag f) = [f]
     functions Binds{bindGroup} = concat $ M.elems bindGroup

--- a/src/NITTA/Model/Problems/Bind.hs
+++ b/src/NITTA/Model/Problems/Bind.hs
@@ -60,6 +60,7 @@ instance UnitTag tag => Show (Bind tag v x) where
 showFAndTag :: UnitTag tag => (F v x, tag) -> String
 showFAndTag (f, tag) = toString tag <> " <- " <> show f
 
+showFsAndTag :: (ToString a1, Show a2) => (a1, [a2]) -> String
 showFsAndTag (tag, fs) = toString tag <> " <- " <> S.join ", " (map show fs)
 
 class BindProblem u tag v x | u -> tag v x where

--- a/src/NITTA/Model/Problems/ViewHelper.hs
+++ b/src/NITTA/Model/Problems/ViewHelper.hs
@@ -10,7 +10,9 @@ module NITTA.Model.Problems.ViewHelper (
 ) where
 
 import Data.Aeson
-import Data.Bifunctor
+import Data.Bifunctor (Bifunctor (bimap))
+import Data.HashMap.Strict qualified as HM
+import Data.Map.Strict qualified as M
 import Data.Set qualified as S
 import Data.Text qualified as T
 import GHC.Generics
@@ -34,6 +36,9 @@ data DecisionView
     | BindDecisionView
         { function :: FView
         , pu :: T.Text
+        }
+    | BindsView
+        { bindGroup :: HM.HashMap T.Text [FView]
         }
     | AllocationView
         { networkTag :: T.Text
@@ -68,6 +73,7 @@ instance UnitTag tag => Viewable (Bind tag v x) DecisionView where
             { function = view f
             , pu = toText pu
             }
+    view Binds{bindGroup} = BindsView $ HM.fromList $ map (bimap toText (map view)) $ M.assocs bindGroup
 
 instance UnitTag tag => Viewable (Allocation tag) DecisionView where
     view Allocation{networkTag, processUnitTag} =

--- a/src/NITTA/Model/Problems/ViewHelper.hs
+++ b/src/NITTA/Model/Problems/ViewHelper.hs
@@ -33,11 +33,11 @@ instance ToJSON IntervalView
 
 data DecisionView
     = RootView
-    | BindDecisionView
+    | SingleBindView
         { function :: FView
         , pu :: T.Text
         }
-    | BindsView
+    | GroupBindView
         { bindGroup :: HM.HashMap T.Text [FView]
         }
     | AllocationView
@@ -68,12 +68,12 @@ data DecisionView
     deriving (Generic)
 
 instance UnitTag tag => Viewable (Bind tag v x) DecisionView where
-    view (Bind uTag f) =
-        BindDecisionView
+    view (SingleBind uTag f) =
+        SingleBindView
             { function = view f
             , pu = toText uTag
             }
-    view Binds{bindGroup} = BindsView $ HM.fromList $ map (bimap toText (map view)) $ M.assocs bindGroup
+    view GroupBind{bindGroup} = GroupBindView $ HM.fromList $ map (bimap toText (map view)) $ M.assocs bindGroup
 
 instance UnitTag tag => Viewable (Allocation tag) DecisionView where
     view Allocation{networkTag, processUnitTag} =

--- a/src/NITTA/Model/Problems/ViewHelper.hs
+++ b/src/NITTA/Model/Problems/ViewHelper.hs
@@ -68,10 +68,10 @@ data DecisionView
     deriving (Generic)
 
 instance UnitTag tag => Viewable (Bind tag v x) DecisionView where
-    view (Bind f pu) =
+    view (Bind uTag f) =
         BindDecisionView
             { function = view f
-            , pu = toText pu
+            , pu = toText uTag
             }
     view Binds{bindGroup} = BindsView $ HM.fromList $ map (bimap toText (map view)) $ M.assocs bindGroup
 

--- a/src/NITTA/Synthesis/Explore.hs
+++ b/src/NITTA/Synthesis/Explore.hs
@@ -170,7 +170,7 @@ nodeCtx parent nModel =
             , bindingAlternative =
                 foldl
                     ( \st b -> case b of
-                        (Bind f tag) -> M.alter (return . maybe [tag] (tag :)) f st
+                        (Bind uTag f) -> M.alter (return . maybe [uTag] (uTag :)) f st
                         _ -> st
                     )
                     M.empty
@@ -178,9 +178,9 @@ nodeCtx parent nModel =
             , possibleDeadlockBinds =
                 S.fromList
                     [ f
-                    | (Bind f tag) <- sBindOptions
+                    | (Bind uTag f) <- sBindOptions
                     , Lock{lockBy} <- locks f
-                    , lockBy `S.member` unionsMap variables (bindedFunctions tag $ mUnit nModel)
+                    , lockBy `S.member` unionsMap variables (bindedFunctions uTag $ mUnit nModel)
                     ]
             , bindWaves = estimateVarWaves (S.elems (variables (mUnit nModel) S.\\ unionsMap variables sBindOptions)) fs
             , processWaves

--- a/src/NITTA/Synthesis/Explore.hs
+++ b/src/NITTA/Synthesis/Explore.hs
@@ -170,7 +170,7 @@ nodeCtx parent nModel =
             , bindingAlternative =
                 foldl
                     ( \st b -> case b of
-                        (Bind uTag f) -> M.alter (return . maybe [uTag] (uTag :)) f st
+                        (SingleBind uTag f) -> M.alter (return . maybe [uTag] (uTag :)) f st
                         _ -> st
                     )
                     M.empty
@@ -178,7 +178,7 @@ nodeCtx parent nModel =
             , possibleDeadlockBinds =
                 S.fromList
                     [ f
-                    | (Bind uTag f) <- sBindOptions
+                    | (SingleBind uTag f) <- sBindOptions
                     , Lock{lockBy} <- locks f
                     , lockBy `S.member` unionsMap variables (bindedFunctions uTag $ mUnit nModel)
                     ]

--- a/src/NITTA/Synthesis/Explore.hs
+++ b/src/NITTA/Synthesis/Explore.hs
@@ -192,4 +192,13 @@ nodeCtx parent nModel =
                     | (DataflowSt _ targets) <- sDataflowOptions
                     , (_, ep) <- targets
                     ]
+            , unitWorkloadInFunction =
+                let
+                    BusNetwork{bnBinded, bnPus} = mUnit nModel
+                 in
+                    M.fromList
+                        $ map
+                            ( \uTag -> (uTag, maybe 0 length $ bnBinded M.!? uTag)
+                            )
+                        $ M.keys bnPus
             }

--- a/src/NITTA/Synthesis/Explore.hs
+++ b/src/NITTA/Synthesis/Explore.hs
@@ -169,7 +169,10 @@ nodeCtx parent nModel =
             , sOptimizeAccumOptions = optimizeAccumOptions nModel
             , bindingAlternative =
                 foldl
-                    (\st (Bind f tag) -> M.alter (return . maybe [tag] (tag :)) f st)
+                    ( \st b -> case b of
+                        (Bind f tag) -> M.alter (return . maybe [tag] (tag :)) f st
+                        _ -> st
+                    )
                     M.empty
                     sBindOptions
             , possibleDeadlockBinds =

--- a/src/NITTA/Synthesis/Method.hs
+++ b/src/NITTA/Synthesis/Method.hs
@@ -102,8 +102,8 @@ obviousBindThreadIO tree = do
     maybe (return tree) obviousBindThreadIO $
         L.find
             ( ( \case
-                    Just BindMetrics{pPossibleDeadlock = True} -> False
-                    Just BindMetrics{pAlternative = 1} -> True
+                    Just SingleBindMetrics{pPossibleDeadlock = True} -> False
+                    Just SingleBindMetrics{pAlternative = 1} -> True
                     _ -> False
               )
                 . cast

--- a/src/NITTA/Synthesis/Method.hs
+++ b/src/NITTA/Synthesis/Method.hs
@@ -26,6 +26,7 @@ module NITTA.Synthesis.Method (
 import Data.List qualified as L
 import Data.Typeable
 import Debug.Trace
+import NITTA.Model.Networks.Bus (BusNetwork)
 import NITTA.Model.ProcessorUnits
 import NITTA.Model.TargetSystem
 import NITTA.Synthesis.Explore
@@ -53,11 +54,8 @@ stateOfTheArtSynthesisIO () tree = do
     l2 <- smartBindSynthesisIO tree
     l3 <- bestThreadIO stepLimit tree
     l4 <- bestThreadIO stepLimit =<< allBindsAndRefsIO tree
-    return $ bestLeaf tree [l1, l2, l3, l4]
-
--- FIXME: Write me
--- allGroupBindsSynthesisIO :: (VarValTime v x t, UnitTag tag) => SynthesisMethod tag v x t
--- allGroupBindsSynthesisIO
+    l5 <- obliviousGroupBindsIO tree >>= tryAllGroupBindsByIO (bestThreadIO stepLimit)
+    return $ bestLeaf tree [l1, l2, l3, l4, l5]
 
 -- | Schedule process by simple synthesis.
 simpleSynthesisIO :: (VarValTime v x t, UnitTag tag) => SynthesisMethod tag v x t
@@ -87,6 +85,17 @@ bestStepIO tree = do
         [] -> error "all step is over"
         _ -> return $ maximumOn (defScore . sDecision) subForest
 
+obliviousGroupBindsIO :: (VarValTime v x t, UnitTag tag) => SynthesisMethod tag v x t
+obliviousGroupBindsIO tree = do
+    binds <- selectSubForestIO isObliviousMultiBind tree
+    maybe (return tree) obliviousGroupBindsIO $ bestDecision binds
+
+tryAllGroupBindsByIO :: (VarValTime v x t, UnitTag tag) => SynthesisMethod tag v x t -> SynthesisMethod tag v x t
+tryAllGroupBindsByIO method tree = do
+    bindSubForest <- selectSubForestIO isMultiBind tree
+    leafs <- mapM method bindSubForest
+    return $ bestLeaf tree leafs
+
 obviousBindThreadIO :: (VarValTime v x t, UnitTag tag) => SynthesisMethod tag v x t
 obviousBindThreadIO tree = do
     subForest <- positiveSubForestIO tree
@@ -105,12 +114,13 @@ obviousBindThreadIO tree = do
 allBindsAndRefsIO :: (VarValTime v x t, UnitTag tag) => SynthesisMethod tag v x t
 allBindsAndRefsIO tree = do
     subForest <-
-        filter ((\d -> isBind d || isRefactor d) . sDecision)
+        filter ((\d -> isSingleBind d || isRefactor d) . sDecision)
             <$> positiveSubForestIO tree
     case subForest of
         [] -> return tree
         _ -> allBindsAndRefsIO $ maximumOn (defScore . sDecision) subForest
 
+refactorThreadIO :: (VarValTime v x t, UnitTag tag) => SynthesisMethod tag v x t
 refactorThreadIO tree = do
     subForest <- positiveSubForestIO tree
     maybe (return tree) refactorThreadIO $
@@ -119,7 +129,7 @@ refactorThreadIO tree = do
 smartBindThreadIO :: (VarValTime v x t, UnitTag tag) => SynthesisMethod tag v x t
 smartBindThreadIO tree = do
     subForest <-
-        filter ((\d -> isBind d || isRefactor d) . sDecision)
+        filter ((\d -> isSingleBind d || isRefactor d) . sDecision)
             <$> (positiveSubForestIO =<< refactorThreadIO tree)
     case subForest of
         [] -> return tree
@@ -141,3 +151,20 @@ bestLeaf tree leafs =
                 minimumOn
                     (\Tree{sState = SynthesisState{sTarget}} -> (processDuration sTarget, puSize sTarget))
                     successLeafs
+
+-- * Helpers
+
+selectSubForestIO ::
+    ( UnitTag tag
+    , VarValTime v x t
+    , m ~ TargetSystem (BusNetwork tag v x t) tag v x t
+    , ctx ~ SynthesisState m tag v x t
+    ) =>
+    (SynthesisDecision ctx m -> Bool) ->
+    DefTree tag v x t ->
+    IO [DefTree tag v x t]
+selectSubForestIO p tree = filter (p . sDecision) <$> positiveSubForestIO tree
+
+bestDecision :: [DefTree tag v x t] -> Maybe (DefTree tag v x t)
+bestDecision [] = Nothing
+bestDecision xs = Just $ maximumOn (defScore . sDecision) xs

--- a/src/NITTA/Synthesis/Method.hs
+++ b/src/NITTA/Synthesis/Method.hs
@@ -55,6 +55,10 @@ stateOfTheArtSynthesisIO () tree = do
     l4 <- bestThreadIO stepLimit =<< allBindsAndRefsIO tree
     return $ bestLeaf tree [l1, l2, l3, l4]
 
+-- FIXME: Write me
+-- allGroupBindsSynthesisIO :: (VarValTime v x t, UnitTag tag) => SynthesisMethod tag v x t
+-- allGroupBindsSynthesisIO
+
 -- | Schedule process by simple synthesis.
 simpleSynthesisIO :: (VarValTime v x t, UnitTag tag) => SynthesisMethod tag v x t
 simpleSynthesisIO root = do

--- a/src/NITTA/Synthesis/Steps/Bind.hs
+++ b/src/NITTA/Synthesis/Steps/Bind.hs
@@ -111,11 +111,11 @@ instance
                     waves | all isJust waves -> Just $ maximum $ catMaybes waves
                     _ -> Nothing
                 }
-    parameters SynthesisState{sTarget, unitWorkloadInFunction} binds@Binds{isSingleAssignment, bindGroup} _ =
+    parameters SynthesisState{sTarget, unitWorkloadInFunction} binds@Binds{isObliviousBinds, bindGroup} _ =
         let dfgFunCount = length $ functions $ mDataFlowGraph sTarget
             bindFunCount = length $ functions binds
          in BindsMetrics
-                { pOnlyObliviousBinds = isSingleAssignment
+                { pOnlyObliviousBinds = isObliviousBinds
                 , pFunctionPercentInBinds = fromIntegral bindFunCount / fromIntegral dfgFunCount
                 , pAvgBinds = avg $ map (fromIntegral . length . snd) $ M.assocs bindGroup
                 , pVarianceBinds = stddev $ map (fromIntegral . length . snd) $ M.assocs bindGroup

--- a/src/NITTA/Synthesis/Steps/Bind.hs
+++ b/src/NITTA/Synthesis/Steps/Bind.hs
@@ -128,10 +128,12 @@ instance
                 let lstAvg = avg lst
                  in sqrt $ avg $ map (\x -> (x - lstAvg) ^ (2 :: Int)) lst
 
-    estimate _ctx _o _d BindsMetrics{pSingleAssingmentBinds} =
+    estimate _ctx _o _d BindsMetrics{pSingleAssingmentBinds, pVarInBindPercent, pVarianceBinds} =
         sum
-            [ 4000
+            [ 4100
             , pSingleAssingmentBinds <?> 1000
+            , fromInteger $ round pVarInBindPercent * 10
+            , fromInteger $ round pVarianceBinds * (-20)
             ]
     estimate _ctx _o _d BindMetrics{pPossibleDeadlock = True} = 500
     estimate _ctx _o _d BindMetrics{pCritical, pAlternative, pAllowDataFlow, pRestless, pNumberOfBindedFunctions, pWave, pPercentOfBindedInputs, pOutputNumber} =

--- a/src/NITTA/Synthesis/Steps/Bind.hs
+++ b/src/NITTA/Synthesis/Steps/Bind.hs
@@ -34,24 +34,39 @@ import NITTA.Synthesis.Types
 import NITTA.Utils
 import Numeric.Interval.NonEmpty (inf)
 
-data BindMetrics = BindMetrics
-    { pCritical :: Bool
-    -- ^ Can this binding block another one (for example, one 'Loop' can
-    --  take the last free buffer)?
-    , pAlternative :: Float
-    -- ^ How many alternative binding we have?
-    , pRestless :: Float
-    -- ^ How many ticks requires for executing the function?
-    , pOutputNumber :: Float
-    , pAllowDataFlow :: Float
-    -- ^ How many transactions can be executed with this function?
-    , pPossibleDeadlock :: Bool
-    -- ^ May this binding cause deadlock?
-    , pNumberOfBindedFunctions :: Float
-    , pPercentOfBindedInputs :: Float
-    -- ^ number of binded input variables / number of all input variables
-    , pWave :: Maybe Float
-    }
+data BindMetrics
+    = BindMetrics
+        { pCritical :: Bool
+        -- ^ Can this binding block another one (for example, one 'Loop' can
+        --  take the last free buffer)?
+        , pAlternative :: Float
+        -- ^ How many alternative binding we have?
+        , pRestless :: Float
+        -- ^ How many ticks requires for executing the function?
+        , pOutputNumber :: Float
+        , pAllowDataFlow :: Float
+        -- ^ How many transactions can be executed with this function?
+        , pPossibleDeadlock :: Bool
+        -- ^ May this binding cause deadlock?
+        , pNumberOfBindedFunctions :: Float
+        , pPercentOfBindedInputs :: Float
+        -- ^ number of binded input variables / number of all input variables
+        , pWave :: Maybe Float
+        }
+    | BindsMetrics
+        { pSingleAssingmentBinds :: Bool
+        -- ^ Is there a single assignment bind only
+        , pVarInBindPercent :: Float
+        -- ^ number of binded functions / number of all functions in DFG
+        , pAvgBinds :: Float
+        -- ^ average number of binds per unit
+        , pVarianceBinds :: Float
+        -- ^ variance of binds per unit
+        , pAvgVariablesAfterBind :: Float
+        -- ^ average number of variables after bind per unit
+        , pVarianceVariablesAfterBind :: Float
+        -- ^ variance of variables after bind per unit
+        }
     deriving (Generic)
 
 instance ToJSON BindMetrics
@@ -96,7 +111,28 @@ instance
                     waves | all isJust waves -> Just $ maximum $ catMaybes waves
                     _ -> Nothing
                 }
+    parameters SynthesisState{sTarget} binds@Binds{isSingleAssignment, bindGroup} _ =
+        let dfgFunCount = length $ functions $ mDataFlowGraph sTarget
+            bindFunCount = length $ functions binds
+         in BindsMetrics
+                { pSingleAssingmentBinds = isSingleAssignment
+                , pVarInBindPercent = fromIntegral bindFunCount / fromIntegral dfgFunCount
+                , pAvgBinds = avg $ map (fromIntegral . length . snd) $ M.assocs bindGroup
+                , pVarianceBinds = stddev $ map (fromIntegral . length . snd) $ M.assocs bindGroup
+                , pAvgVariablesAfterBind = 0
+                , pVarianceVariablesAfterBind = 0
+                }
+        where
+            avg lst = sum lst / fromIntegral (length lst)
+            stddev lst =
+                let lstAvg = avg lst
+                 in sqrt $ avg $ map (\x -> (x - lstAvg) ^ (2 :: Int)) lst
 
+    estimate _ctx _o _d BindsMetrics{pSingleAssingmentBinds} =
+        sum
+            [ 4000
+            , pSingleAssingmentBinds <?> 1000
+            ]
     estimate _ctx _o _d BindMetrics{pPossibleDeadlock = True} = 500
     estimate _ctx _o _d BindMetrics{pCritical, pAlternative, pAllowDataFlow, pRestless, pNumberOfBindedFunctions, pWave, pPercentOfBindedInputs, pOutputNumber} =
         sum

--- a/src/NITTA/Synthesis/Steps/Bind.hs
+++ b/src/NITTA/Synthesis/Steps/Bind.hs
@@ -37,7 +37,7 @@ import NITTA.Utils
 import Numeric.Interval.NonEmpty (inf)
 
 data BindMetrics
-    = BindMetrics
+    = SingleBindMetrics
         { pCritical :: Bool
         -- ^ Can this binding block another one (for example, one 'Loop' can
         --  take the last free buffer)?
@@ -55,7 +55,7 @@ data BindMetrics
         -- ^ number of binded input variables / number of all input variables
         , pWave :: Maybe Float
         }
-    | BindsMetrics
+    | GroupBindMetrics
         { pOnlyObliviousBinds :: Bool
         -- ^ We don't have alternatives for binding
         , pFunctionPercentInBinds :: Float
@@ -91,9 +91,9 @@ instance
             , possibleDeadlockBinds
             , bindWaves
             }
-        (Bind tag f)
+        (SingleBind tag f)
         _ =
-            BindMetrics
+            SingleBindMetrics
                 { pCritical = isInternalLockPossible f
                 , pAlternative = fromIntegral $ length (bindingAlternative M.! f)
                 , pAllowDataFlow = fromIntegral $ length $ unionsMap variables $ filter isTarget $ optionsAfterBind f tag sTarget
@@ -113,10 +113,10 @@ instance
                     waves | all isJust waves -> Just $ maximum $ catMaybes waves
                     _ -> Nothing
                 }
-    parameters SynthesisState{sTarget, unitWorkloadInFunction} binds@Binds{isObliviousBinds, bindGroup} _ =
+    parameters SynthesisState{sTarget, unitWorkloadInFunction} binds@GroupBind{isObliviousBinds, bindGroup} _ =
         let dfgFunCount = length $ functions $ mDataFlowGraph sTarget
             bindFunCount = length $ functions binds
-         in BindsMetrics
+         in GroupBindMetrics
                 { pOnlyObliviousBinds = isObliviousBinds
                 , pFunctionPercentInBinds = fromIntegral bindFunCount / fromIntegral dfgFunCount
                 , pAvgBinds = avg $ map (fromIntegral . length . snd) $ M.assocs bindGroup
@@ -131,26 +131,39 @@ instance
                 let lstAvg = avg lst
                  in sqrt $ avg $ map (\x -> (x - lstAvg) ^ (2 :: Int)) lst
 
-    estimate _ctx _o _d BindsMetrics{pOnlyObliviousBinds, pFunctionPercentInBinds, pVarianceBinds} =
+    estimate _ctx _o _d GroupBindMetrics{pOnlyObliviousBinds, pFunctionPercentInBinds, pVarianceBinds} =
         sum
             [ 4100
             , pOnlyObliviousBinds <?> 1000
             , fromInteger $ round pFunctionPercentInBinds * 10
             , fromInteger $ round pVarianceBinds * (-20)
             ]
-    estimate _ctx _o _d BindMetrics{pPossibleDeadlock = True} = 500
-    estimate _ctx _o _d BindMetrics{pCritical, pAlternative, pAllowDataFlow, pRestless, pNumberOfBindedFunctions, pWave, pPercentOfBindedInputs, pOutputNumber} =
-        sum
-            [ 3000
-            , pCritical <?> 1000
-            , (pAlternative == 1) <?> 500
-            , pAllowDataFlow * 10
-            , pPercentOfBindedInputs * 50
-            , -fromMaybe (-1) pWave * 50
-            , -pNumberOfBindedFunctions * 10
-            , -pRestless * 4
-            , pOutputNumber * 2
-            ]
+    estimate _ctx _o _d SingleBindMetrics{pPossibleDeadlock = True} = 500
+    estimate
+        _ctx
+        _o
+        _d
+        SingleBindMetrics
+            { pCritical
+            , pAlternative
+            , pAllowDataFlow
+            , pRestless
+            , pNumberOfBindedFunctions
+            , pWave
+            , pPercentOfBindedInputs
+            , pOutputNumber
+            } =
+            sum
+                [ 3000
+                , pCritical <?> 1000
+                , (pAlternative == 1) <?> 500
+                , pAllowDataFlow * 10
+                , pPercentOfBindedInputs * 50
+                , -fromMaybe (-1) pWave * 50
+                , -pNumberOfBindedFunctions * 10
+                , -pRestless * 4
+                , pOutputNumber * 2
+                ]
 
 waitingTimeOfVariables net =
     [ (variable, inf $ tcAvailable constrain)
@@ -168,15 +181,15 @@ optionsAfterBind f tag TargetSystem{mUnit = BusNetwork{bnPus}} =
 
 isSingleBind :: SynthesisDecision ctx m -> Bool
 isSingleBind SynthesisDecision{metrics}
-    | Just BindMetrics{} <- cast metrics :: Maybe BindMetrics = True
+    | Just SingleBindMetrics{} <- cast metrics :: Maybe BindMetrics = True
 isSingleBind _ = False
 
 isMultiBind :: SynthesisDecision ctx m -> Bool
 isMultiBind SynthesisDecision{metrics}
-    | Just BindsMetrics{} <- cast metrics :: Maybe BindMetrics = True
+    | Just GroupBindMetrics{} <- cast metrics :: Maybe BindMetrics = True
 isMultiBind _ = False
 
 isObliviousMultiBind :: SynthesisDecision ctx m -> Bool
 isObliviousMultiBind SynthesisDecision{metrics}
-    | Just BindsMetrics{pOnlyObliviousBinds = True} <- cast metrics :: Maybe BindMetrics = True
+    | Just GroupBindMetrics{pOnlyObliviousBinds = True} <- cast metrics :: Maybe BindMetrics = True
 isObliviousMultiBind _ = False

--- a/src/NITTA/Synthesis/Steps/Bind.hs
+++ b/src/NITTA/Synthesis/Steps/Bind.hs
@@ -91,7 +91,7 @@ instance
             , possibleDeadlockBinds
             , bindWaves
             }
-        (Bind f tag)
+        (Bind tag f)
         _ =
             BindMetrics
                 { pCritical = isInternalLockPossible f

--- a/src/NITTA/Synthesis/Steps/Bind.hs
+++ b/src/NITTA/Synthesis/Steps/Bind.hs
@@ -13,7 +13,9 @@ Stability   : experimental
 -}
 module NITTA.Synthesis.Steps.Bind (
     BindMetrics (..),
-    isBind,
+    isSingleBind,
+    isMultiBind,
+    isObliviousMultiBind,
 ) where
 
 import Data.Aeson (ToJSON)
@@ -164,6 +166,17 @@ optionsAfterBind f tag TargetSystem{mUnit = BusNetwork{bnPus}} =
     where
         act `optionOf` f' = not $ S.null (variables act `S.intersection` variables f')
 
-isBind SynthesisDecision{metrics}
-    | isJust (cast metrics :: Maybe BindMetrics) = True
-isBind _ = False
+isSingleBind :: SynthesisDecision ctx m -> Bool
+isSingleBind SynthesisDecision{metrics}
+    | Just BindMetrics{} <- cast metrics :: Maybe BindMetrics = True
+isSingleBind _ = False
+
+isMultiBind :: SynthesisDecision ctx m -> Bool
+isMultiBind SynthesisDecision{metrics}
+    | Just BindsMetrics{} <- cast metrics :: Maybe BindMetrics = True
+isMultiBind _ = False
+
+isObliviousMultiBind :: SynthesisDecision ctx m -> Bool
+isObliviousMultiBind SynthesisDecision{metrics}
+    | Just BindsMetrics{pOnlyObliviousBinds = True} <- cast metrics :: Maybe BindMetrics = True
+isObliviousMultiBind _ = False

--- a/src/NITTA/Synthesis/Types.hs
+++ b/src/NITTA/Synthesis/Types.hs
@@ -132,6 +132,7 @@ data SynthesisDecision ctx m where
         {option :: o, decision :: d, metrics :: p, scores :: Map Text Float} ->
         SynthesisDecision ctx m
 
+defScore :: SynthesisDecision ctx m -> Float
 defScore = (M.! "default") . scores
 
 class SynthesisDecisionCls ctx m o d p | ctx o -> m d p where

--- a/src/NITTA/Synthesis/Types.hs
+++ b/src/NITTA/Synthesis/Types.hs
@@ -169,6 +169,7 @@ data SynthesisState m tag v x t = SynthesisState
     , transferableVars :: S.Set v
     -- ^ a variable set, which can be transferred on the current
     --  synthesis step
+    , unitWorkloadInFunction :: M.Map tag Int
     }
 
 -- * Utils

--- a/src/NITTA/Synthesis/Types.hs
+++ b/src/NITTA/Synthesis/Types.hs
@@ -170,6 +170,7 @@ data SynthesisState m tag v x t = SynthesisState
     -- ^ a variable set, which can be transferred on the current
     --  synthesis step
     , unitWorkloadInFunction :: M.Map tag Int
+    -- ^ dictionary with number of binded functions for each unit
     }
 
 -- * Utils

--- a/src/NITTA/UIBackend/ViewHelper.hs
+++ b/src/NITTA/UIBackend/ViewHelper.hs
@@ -157,7 +157,8 @@ viewNodeTree tree@Tree{sID = sid, sDecision, sSubForestVar} = do
                         Root{} -> "root"
                         SynthesisDecision{metrics}
                             | Just AllocationMetrics{} <- cast metrics -> "Allocation"
-                            | Just BindMetrics{} <- cast metrics -> "Bind"
+                            | Just SingleBindMetrics{} <- cast metrics -> "SingleBind"
+                            | Just GroupBindMetrics{} <- cast metrics -> "GroupBind"
                             | Just BreakLoopMetrics{} <- cast metrics -> "Refactor"
                             | Just ConstantFoldingMetrics{} <- cast metrics -> "Refactor"
                             | Just DataflowMetrics{} <- cast metrics -> "Transport"
@@ -219,7 +220,7 @@ instance ToSample (NodeView tag v x t) where
                 , duration = 0
                 , parameters =
                     toJSON $
-                        BindMetrics
+                        SingleBindMetrics
                             { pCritical = False
                             , pAlternative = 1
                             , pRestless = 0
@@ -230,7 +231,7 @@ instance ToSample (NodeView tag v x t) where
                             , pPercentOfBindedInputs = 0.2
                             , pWave = Just 2
                             }
-                , decision = BindDecisionView (FView "buffer(a) = b = c" []) "pu"
+                , decision = SingleBindView (FView "buffer(a) = b = c" []) "pu"
                 , score = 1032
                 }
             , NodeView

--- a/test/NITTA/Model/ProcessorUnits/Tests/DSL.hs
+++ b/test/NITTA/Model/ProcessorUnits/Tests/DSL.hs
@@ -439,7 +439,7 @@ synthesis method = do
 doBind :: T.Text -> F T.Text x -> TSStatement x ()
 doBind uTag f = do
     st@UnitTestState{unit = ts} <- get
-    let d = Bind uTag f
+    let d = SingleBind uTag f
         opts = bindOptions ts
     unless (d `L.elem` opts) $
         lift $

--- a/test/NITTA/Model/ProcessorUnits/Tests/DSL.hs
+++ b/test/NITTA/Model/ProcessorUnits/Tests/DSL.hs
@@ -437,9 +437,9 @@ synthesis method = do
     put st{unit = sTarget $ sState leaf}
 
 doBind :: T.Text -> F T.Text x -> TSStatement x ()
-doBind tag f = do
+doBind uTag f = do
     st@UnitTestState{unit = ts} <- get
-    let d = Bind f tag
+    let d = Bind uTag f
         opts = bindOptions ts
     unless (d `L.elem` opts) $
         lift $

--- a/web/src/components/IntermediateView.tsx
+++ b/web/src/components/IntermediateView.tsx
@@ -4,7 +4,7 @@ import { Graphviz } from "graphviz-react";
 
 import { AppContext, IAppContext } from "app/AppContext";
 import { GraphNode, GraphEdge } from "services/gen/types";
-import { api, IntermediateGraph, Dataflow, Bind, Node } from "services/HaskellApiService";
+import { api, IntermediateGraph, Dataflow, SingleBind, Node } from "services/HaskellApiService";
 import { UnitEndpointsData, EndpointOptionData, EndpointDecision } from "services/HaskellApiService";
 import { DownloadTextFile } from "utils/download";
 
@@ -162,8 +162,8 @@ function makeProcState(nodes: Node[]): ProcessState {
         procState.transferedVars.push(target[1].epRole.contents as string);
       });
     }
-    if (n.decision.tag === "BindDecisionView") {
-      let d = n.decision as Bind;
+    if (n.decision.tag === "SingleBindView") {
+      let d = n.decision as SingleBind;
       procState.bindeFuns.push(d.function.fvFun, ...d.function.fvHistory);
     }
   });

--- a/web/src/components/SubforestTables.tsx
+++ b/web/src/components/SubforestTables.tsx
@@ -56,16 +56,12 @@ export const SubforestTables: FC<SubforestTablesProps> = ({ nodes }) => {
           textColumn("type", (e: Node) => e.decision.tag, 160),
           textColumn("description", (e: Node) => showDecision(e.decision)),
 
-          textColumn("oblivious", (e: Node) => String((e.parameters as IBindsMetrics).pSingleAssingmentBinds), 75),
-          textColumn("percent", (e: Node) => String((e.parameters as IBindsMetrics).pVarInBindPercent), 75),
+          textColumn("oblivious", (e: Node) => String((e.parameters as IBindsMetrics).pOnlyObliviousBinds), 75),
+          textColumn("percent", (e: Node) => String((e.parameters as IBindsMetrics).pFunctionPercentInBinds), 75),
           textColumn("avg", (e: Node) => String((e.parameters as IBindsMetrics).pAvgBinds), 50),
           textColumn("variance", (e: Node) => String((e.parameters as IBindsMetrics).pVarianceBinds), 75),
-          textColumn("avgAfter", (e: Node) => String((e.parameters as IBindsMetrics).pAvgVariablesAfterBind), 50),
-          textColumn(
-            "varianceAfter",
-            (e: Node) => String((e.parameters as IBindsMetrics).pVarianceVariablesAfterBind),
-            50
-          ),
+          textColumn("avgLoad", (e: Node) => String((e.parameters as IBindsMetrics).pAvgUnitWorkload), 75),
+          textColumn("varianceLoad", (e: Node) => String((e.parameters as IBindsMetrics).pVarianceUnitWorkload), 100),
 
           detailColumn(),
         ]}

--- a/web/src/components/SubforestTables.tsx
+++ b/web/src/components/SubforestTables.tsx
@@ -3,7 +3,7 @@ import ReactTable, { Column } from "react-table";
 
 import { AppContext, IAppContext } from "app/AppContext";
 import { Node, Dataflow } from "services/HaskellApiService";
-import { BindMetrics, AllocationMetrics, DataflowMetrics } from "services/gen/types";
+import { IBindMetrics, IBindsMetrics, AllocationMetrics, DataflowMetrics } from "services/gen/types";
 import {
   sidColumn,
   textColumn,
@@ -26,6 +26,8 @@ export const SubforestTables: FC<SubforestTablesProps> = ({ nodes }) => {
   };
   let known = [
     "RootView",
+    "SingleAssingmentBindsView",
+    "BindsView",
     "AllocationView",
     "BindDecisionView",
     "DataflowDecisionView",
@@ -46,6 +48,29 @@ export const SubforestTables: FC<SubforestTablesProps> = ({ nodes }) => {
   return (
     <>
       <Table
+        name="GroupBinding"
+        nodes={nodes.filter((e) => ["BindsView"].includes(e.decision.tag))}
+        columns={[
+          sidColumn(appContext.setSid),
+          objectiveColumn(scoresInfo),
+          textColumn("type", (e: Node) => e.decision.tag, 160),
+          textColumn("description", (e: Node) => showDecision(e.decision)),
+
+          textColumn("oblivious", (e: Node) => String((e.parameters as IBindsMetrics).pSingleAssingmentBinds), 75),
+          textColumn("percent", (e: Node) => String((e.parameters as IBindsMetrics).pVarInBindPercent), 75),
+          textColumn("avg", (e: Node) => String((e.parameters as IBindsMetrics).pAvgBinds), 50),
+          textColumn("variance", (e: Node) => String((e.parameters as IBindsMetrics).pVarianceBinds), 50),
+          textColumn("avgAfter", (e: Node) => String((e.parameters as IBindsMetrics).pAvgVariablesAfterBind), 50),
+          textColumn(
+            "varianceAfter",
+            (e: Node) => String((e.parameters as IBindsMetrics).pVarianceVariablesAfterBind),
+            50
+          ),
+
+          detailColumn(),
+        ]}
+      />
+      <Table
         name="Binding"
         nodes={nodes.filter((e: Node) => e.decision.tag === "BindDecisionView")}
         columns={[
@@ -54,31 +79,29 @@ export const SubforestTables: FC<SubforestTablesProps> = ({ nodes }) => {
 
           textColumn("description", (e: Node) => showDecision(e.decision)),
 
-          textColumn("crit", (e: Node) => String((e.parameters as BindMetrics).pCritical), 50),
-          textColumn("lock", (e: Node) => String((e.parameters as BindMetrics).pPossibleDeadlock), 50),
+          textColumn("crit", (e: Node) => String((e.parameters as IBindMetrics).pCritical), 50),
+          textColumn("lock", (e: Node) => String((e.parameters as IBindMetrics).pPossibleDeadlock), 50),
           textColumn(
             "wave",
             (e: Node) => {
-              let x = (e.parameters as BindMetrics).pWave;
+              let x = (e.parameters as IBindMetrics).pWave;
               return x === undefined || x === null ? "null" : (x as number).toString();
             },
             50
           ),
-          textColumn("outputs", (e: Node) => (e.parameters as BindMetrics).pOutputNumber, 70),
-          textColumn("alt", (e: Node) => (e.parameters as BindMetrics).pAlternative, 50),
-          textColumn("rest", (e: Node) => (e.parameters as BindMetrics).pRestless, 50),
+          textColumn("outputs", (e: Node) => (e.parameters as IBindMetrics).pOutputNumber, 70),
+          textColumn("alt", (e: Node) => (e.parameters as IBindMetrics).pAlternative, 50),
+          textColumn("rest", (e: Node) => (e.parameters as IBindMetrics).pRestless, 50),
 
-          textColumn("newDF", (e: Node) => (e.parameters as BindMetrics).pAllowDataFlow, 70),
-          textColumn("newBind", (e: Node) => (e.parameters as BindMetrics).pNumberOfBindedFunctions, 70),
-          textColumn("|inputs|", (e: Node) => (e.parameters as BindMetrics).pPercentOfBindedInputs, 70),
+          textColumn("newDF", (e: Node) => (e.parameters as IBindMetrics).pAllowDataFlow, 70),
+          textColumn("newBind", (e: Node) => (e.parameters as IBindMetrics).pNumberOfBindedFunctions, 70),
+          textColumn("|inputs|", (e: Node) => (e.parameters as IBindMetrics).pPercentOfBindedInputs, 70),
           detailColumn(),
         ]}
       />
       <Table
         name="Refactor"
-        nodes={nodes.filter(
-          (e) => !["DataflowDecisionView", "BindDecisionView", "AllocationView"].includes(e.decision.tag)
-        )}
+        nodes={nodes.filter((e) => ["BreakLoopView", "ConstantFoldingView", "AllocationView"].includes(e.decision.tag))}
         columns={[
           sidColumn(appContext.setSid),
           objectiveColumn(scoresInfo),

--- a/web/src/components/SubforestTables.tsx
+++ b/web/src/components/SubforestTables.tsx
@@ -59,7 +59,7 @@ export const SubforestTables: FC<SubforestTablesProps> = ({ nodes }) => {
           textColumn("oblivious", (e: Node) => String((e.parameters as IBindsMetrics).pSingleAssingmentBinds), 75),
           textColumn("percent", (e: Node) => String((e.parameters as IBindsMetrics).pVarInBindPercent), 75),
           textColumn("avg", (e: Node) => String((e.parameters as IBindsMetrics).pAvgBinds), 50),
-          textColumn("variance", (e: Node) => String((e.parameters as IBindsMetrics).pVarianceBinds), 50),
+          textColumn("variance", (e: Node) => String((e.parameters as IBindsMetrics).pVarianceBinds), 75),
           textColumn("avgAfter", (e: Node) => String((e.parameters as IBindsMetrics).pAvgVariablesAfterBind), 50),
           textColumn(
             "varianceAfter",

--- a/web/src/components/SubforestTables.tsx
+++ b/web/src/components/SubforestTables.tsx
@@ -3,7 +3,7 @@ import ReactTable, { Column } from "react-table";
 
 import { AppContext, IAppContext } from "app/AppContext";
 import { Node, Dataflow } from "services/HaskellApiService";
-import { IBindMetrics, IBindsMetrics, AllocationMetrics, DataflowMetrics } from "services/gen/types";
+import { ISingleBindMetrics, IGroupBindMetrics, AllocationMetrics, DataflowMetrics } from "services/gen/types";
 import {
   sidColumn,
   textColumn,
@@ -26,10 +26,9 @@ export const SubforestTables: FC<SubforestTablesProps> = ({ nodes }) => {
   };
   let known = [
     "RootView",
-    "SingleAssingmentBindsView",
-    "BindsView",
+    "GroupBindView",
     "AllocationView",
-    "BindDecisionView",
+    "SingleBindView",
     "DataflowDecisionView",
     "BreakLoopView",
     "ConstantFoldingView",
@@ -49,49 +48,53 @@ export const SubforestTables: FC<SubforestTablesProps> = ({ nodes }) => {
     <>
       <Table
         name="GroupBinding"
-        nodes={nodes.filter((e) => ["BindsView"].includes(e.decision.tag))}
+        nodes={nodes.filter((e) => ["GroupBindView"].includes(e.decision.tag))}
         columns={[
           sidColumn(appContext.setSid),
           objectiveColumn(scoresInfo),
           textColumn("type", (e: Node) => e.decision.tag, 160),
           textColumn("description", (e: Node) => showDecision(e.decision)),
 
-          textColumn("oblivious", (e: Node) => String((e.parameters as IBindsMetrics).pOnlyObliviousBinds), 75),
-          textColumn("percent", (e: Node) => String((e.parameters as IBindsMetrics).pFunctionPercentInBinds), 75),
-          textColumn("avg", (e: Node) => String((e.parameters as IBindsMetrics).pAvgBinds), 50),
-          textColumn("variance", (e: Node) => String((e.parameters as IBindsMetrics).pVarianceBinds), 75),
-          textColumn("avgLoad", (e: Node) => String((e.parameters as IBindsMetrics).pAvgUnitWorkload), 75),
-          textColumn("varianceLoad", (e: Node) => String((e.parameters as IBindsMetrics).pVarianceUnitWorkload), 100),
+          textColumn("oblivious", (e: Node) => String((e.parameters as IGroupBindMetrics).pOnlyObliviousBinds), 75),
+          textColumn("percent", (e: Node) => String((e.parameters as IGroupBindMetrics).pFunctionPercentInBinds), 75),
+          textColumn("avg", (e: Node) => String((e.parameters as IGroupBindMetrics).pAvgBinds), 50),
+          textColumn("variance", (e: Node) => String((e.parameters as IGroupBindMetrics).pVarianceBinds), 75),
+          textColumn("avgLoad", (e: Node) => String((e.parameters as IGroupBindMetrics).pAvgUnitWorkload), 75),
+          textColumn(
+            "varianceLoad",
+            (e: Node) => String((e.parameters as IGroupBindMetrics).pVarianceUnitWorkload),
+            100
+          ),
 
           detailColumn(),
         ]}
       />
       <Table
         name="Binding"
-        nodes={nodes.filter((e: Node) => e.decision.tag === "BindDecisionView")}
+        nodes={nodes.filter((e: Node) => e.decision.tag === "SingleBindView")}
         columns={[
           sidColumn(appContext.setSid),
           objectiveColumn(scoresInfo),
 
           textColumn("description", (e: Node) => showDecision(e.decision)),
 
-          textColumn("crit", (e: Node) => String((e.parameters as IBindMetrics).pCritical), 50),
-          textColumn("lock", (e: Node) => String((e.parameters as IBindMetrics).pPossibleDeadlock), 50),
+          textColumn("crit", (e: Node) => String((e.parameters as ISingleBindMetrics).pCritical), 50),
+          textColumn("lock", (e: Node) => String((e.parameters as ISingleBindMetrics).pPossibleDeadlock), 50),
           textColumn(
             "wave",
             (e: Node) => {
-              let x = (e.parameters as IBindMetrics).pWave;
+              let x = (e.parameters as ISingleBindMetrics).pWave;
               return x === undefined || x === null ? "null" : (x as number).toString();
             },
             50
           ),
-          textColumn("outputs", (e: Node) => (e.parameters as IBindMetrics).pOutputNumber, 70),
-          textColumn("alt", (e: Node) => (e.parameters as IBindMetrics).pAlternative, 50),
-          textColumn("rest", (e: Node) => (e.parameters as IBindMetrics).pRestless, 50),
+          textColumn("outputs", (e: Node) => (e.parameters as ISingleBindMetrics).pOutputNumber, 70),
+          textColumn("alt", (e: Node) => (e.parameters as ISingleBindMetrics).pAlternative, 50),
+          textColumn("rest", (e: Node) => (e.parameters as ISingleBindMetrics).pRestless, 50),
 
-          textColumn("newDF", (e: Node) => (e.parameters as IBindMetrics).pAllowDataFlow, 70),
-          textColumn("newBind", (e: Node) => (e.parameters as IBindMetrics).pNumberOfBindedFunctions, 70),
-          textColumn("|inputs|", (e: Node) => (e.parameters as IBindMetrics).pPercentOfBindedInputs, 70),
+          textColumn("newDF", (e: Node) => (e.parameters as ISingleBindMetrics).pAllowDataFlow, 70),
+          textColumn("newBind", (e: Node) => (e.parameters as ISingleBindMetrics).pNumberOfBindedFunctions, 70),
+          textColumn("|inputs|", (e: Node) => (e.parameters as ISingleBindMetrics).pPercentOfBindedInputs, 70),
           detailColumn(),
         ]}
       />

--- a/web/src/components/SubforestTables/Columns.tsx
+++ b/web/src/components/SubforestTables/Columns.tsx
@@ -5,8 +5,8 @@ import * as Icon from "react-bootstrap-icons";
 
 import {
   Allocation,
-  Binds,
-  Bind,
+  GroupBind,
+  SingleBind,
   Dataflow,
   BreakLoop,
   OptimizeAccum,
@@ -142,8 +142,8 @@ export function objectiveColumn(scoresInfo: ScoresInfo): Column {
 }
 
 export function showDecision(decision: DecisionView): ReactElement {
-  if (decision.tag === "BindDecisionView") return showBind(decision);
-  else if (decision.tag === "BindsView") return showBinds(decision);
+  if (decision.tag === "SingleBindView") return showBind(decision);
+  else if (decision.tag === "GroupBindView") return showBinds(decision);
   else if (decision.tag === "DataflowDecisionView") return showDataflow(decision);
   else if (decision.tag === "BreakLoopView") return showBreakLoop(decision);
   else if (decision.tag === "ConstantFoldingView") return showConstantFolding(decision);
@@ -153,7 +153,7 @@ export function showDecision(decision: DecisionView): ReactElement {
   else throw new Error("Unkown decision type: " + decision.tag);
 }
 
-export function showBinds(decision: Binds): ReactElement {
+export function showBinds(decision: GroupBind): ReactElement {
   const binds = Object.keys(decision.bindGroup).map((uTag: string) => {
     let fs = decision.bindGroup[uTag]!;
     return (
@@ -170,7 +170,7 @@ export function showBinds(decision: Binds): ReactElement {
   return <div> {binds} </div>;
 }
 
-export function showBind(decision: Bind): ReactElement {
+export function showBind(decision: SingleBind): ReactElement {
   return (
     <div>
       <strong>{decision.pu}</strong> <Icon.ArrowLeft /> {decision.function.fvFun}

--- a/web/src/components/SubforestTables/Columns.tsx
+++ b/web/src/components/SubforestTables/Columns.tsx
@@ -5,12 +5,13 @@ import * as Icon from "react-bootstrap-icons";
 
 import {
   Allocation,
+  Binds,
   Bind,
   Dataflow,
   BreakLoop,
   OptimizeAccum,
   ConstantFolding,
-  ResolveDeadlock
+  ResolveDeadlock,
 } from "services/HaskellApiService";
 import { Node, sidSeparator, EndpointDecision, Target } from "services/HaskellApiService";
 import { Interval, FView, DecisionView } from "services/gen/types";
@@ -142,6 +143,7 @@ export function objectiveColumn(scoresInfo: ScoresInfo): Column {
 
 export function showDecision(decision: DecisionView): ReactElement {
   if (decision.tag === "BindDecisionView") return showBind(decision);
+  else if (decision.tag === "BindsView") return showBinds(decision);
   else if (decision.tag === "DataflowDecisionView") return showDataflow(decision);
   else if (decision.tag === "BreakLoopView") return showBreakLoop(decision);
   else if (decision.tag === "ConstantFoldingView") return showConstantFolding(decision);
@@ -149,6 +151,23 @@ export function showDecision(decision: DecisionView): ReactElement {
   else if (decision.tag === "ResolveDeadlockView") return showResolveDeadlock(decision);
   else if (decision.tag === "AllocationView") return showAllocation(decision);
   else throw new Error("Unkown decision type: " + decision.tag);
+}
+
+export function showBinds(decision: Binds): ReactElement {
+  const binds = Object.keys(decision.bindGroup).map((uTag: string) => {
+    let fs = decision.bindGroup[uTag]!;
+    return (
+      <div>
+        <strong>{uTag}</strong> <Icon.ArrowLeft />
+        <ul>
+          {fs.map((e) => (
+            <li key={e.fvFun}>{e.fvFun}</li>
+          ))}
+        </ul>
+      </div>
+    );
+  });
+  return <div> {binds} </div>;
 }
 
 export function showBind(decision: Bind): ReactElement {

--- a/web/src/components/TreeInfoView.tsx
+++ b/web/src/components/TreeInfoView.tsx
@@ -36,14 +36,14 @@ export const TreeInfoView: FC<ITreeInfoViewProps> = (props) => {
             </Col>
             <Col md={4} lg={3}>
               <MapHistogram
-                data={result.data.durationSuccess}
+                data={result.data.targetProcessDuration}
                 color={CHART_COLOR_PALLETE.blue}
                 name="success nodes with duration"
               />
             </Col>
             <Col md={4} lg={3}>
               <MapHistogram
-                data={result.data.stepsSuccess}
+                data={result.data.synthesisStepsForSuccess}
                 color={CHART_COLOR_PALLETE.orange}
                 name="success nodes with steps"
               />

--- a/web/src/components/TreeInfoView.tsx
+++ b/web/src/components/TreeInfoView.tsx
@@ -31,22 +31,24 @@ export const TreeInfoView: FC<ITreeInfoViewProps> = (props) => {
       resultRenderer={(result) => (
         <Container fluid>
           <Row>
-            <Col md={4}>
+            <Col sm={7} md={6} lg={5}>
               <JsonView src={result.data} />
             </Col>
-            <Col md={4} lg={3}>
-              <MapHistogram
-                data={result.data.targetProcessDuration}
-                color={CHART_COLOR_PALLETE.blue}
-                name="success nodes with duration"
-              />
-            </Col>
-            <Col md={4} lg={3}>
-              <MapHistogram
-                data={result.data.synthesisStepsForSuccess}
-                color={CHART_COLOR_PALLETE.orange}
-                name="success nodes with steps"
-              />
+            <Col sm={5} md={5} lg={4}>
+              <Row>
+                <MapHistogram
+                  data={result.data.targetProcessDuration}
+                  color={CHART_COLOR_PALLETE.blue}
+                  name="success nodes with duration"
+                />
+              </Row>
+              <Row>
+                <MapHistogram
+                  data={result.data.synthesisStepsForSuccess}
+                  color={CHART_COLOR_PALLETE.orange}
+                  name="success nodes with steps"
+                />
+              </Row>
             </Col>
           </Row>
         </Container>

--- a/web/src/services/HaskellApiService.ts
+++ b/web/src/services/HaskellApiService.ts
@@ -10,6 +10,7 @@ import {
   IOptimizeAccumView,
   IResolveDeadlockView,
   NetworkDesc,
+  IBindsView,
   UnitDesc,
   Relation,
   TimeConstraint,
@@ -41,6 +42,7 @@ export type Decision = DecisionView;
 export type Root = IRootView;
 
 export type Bind = IBindDecisionView;
+export type Binds = IBindsView;
 export type Allocation = IAllocationView;
 export type Dataflow = IDataflowDecisionView;
 

--- a/web/src/services/HaskellApiService.ts
+++ b/web/src/services/HaskellApiService.ts
@@ -7,10 +7,12 @@ import {
   ShortNodeView,
   IBreakLoopView,
   IConstantFoldingView,
+  IDataflowDecisionView,
   IOptimizeAccumView,
   IResolveDeadlockView,
   NetworkDesc,
-  IBindsView,
+  ISingleBindView,
+  IGroupBindView,
   UnitDesc,
   Relation,
   TimeConstraint,
@@ -20,7 +22,7 @@ import {
   StepInfoView,
   IAllocationView,
 } from "services/gen/types";
-import { NodeView, DecisionView, IRootView, IBindDecisionView, IDataflowDecisionView } from "services/gen/types";
+import { NodeView, DecisionView, IRootView } from "services/gen/types";
 import {
   UnitEndpoints,
   EndpointSt,
@@ -41,8 +43,8 @@ export type Node = NodeView<string, string, number, number>;
 export type Decision = DecisionView;
 export type Root = IRootView;
 
-export type Bind = IBindDecisionView;
-export type Binds = IBindsView;
+export type SingleBind = ISingleBindView;
+export type GroupBind = IGroupBindView;
 export type Allocation = IAllocationView;
 export type Dataflow = IDataflowDecisionView;
 


### PR DESCRIPTION
Add new type of synthesis decision: `Binds`, which contain a set of simple bind the following form:

```haskell
    | GroupBind {isObliviousBinds :: Bool, bindGroup :: M.Map tag [F v x]}
```

With the following metrics to estimate quality of decision:

```haskell
    | GroupBindMetrics
        { pOnlyObliviousBinds :: Bool
        -- ^ We don't have alternatives for binding
        , pFunctionPercentInBinds :: Float
        -- ^ number of binded functions / number of all functions in DFG
        , pAvgBinds :: Float
        -- ^ average number of binds per unit
        , pVarianceBinds :: Float
        -- ^ variance of binds per unit
        , pAvgUnitWorkload :: Float
        -- ^ average number of variables after bind per unit
        , pVarianceUnitWorkload :: Float
        -- ^ variance of variables after bind per unit
        }
```

Be aware about some naming refactoring:

- Bind -> SingleBind
- BindDecisionView -> SingleBindView
- BindMetrics -> SingleBindMetrics
- Reworked TreeInfo fields.

<img width="1121" alt="Screenshot 2023-06-10 at 15 53 59" src="https://github.com/ryukzak/nitta/assets/214731/bcd7ce33-714d-473e-8cf0-d8c13365d76d">
